### PR TITLE
noteの情報取得をGitHubActionsで自動化（修正漏れ対応）

### DIFF
--- a/2026spring/backend/scripts/fetch_videos.py
+++ b/2026spring/backend/scripts/fetch_videos.py
@@ -198,7 +198,7 @@ def main():
         target_keys = tag_config.keys()
 
     # for div in ["rookie", "op", "ex"]:
-    for div in tag_config.keys():
+    for div in target_keys:
         tag = tag_config[div]
         catalog_sheetname = catalog_sheet_config[f"{div}_sheet"]
         catalog_excluded_sheetname = catalog_sheet_config[f"excluded_{div}_sheet"]


### PR DESCRIPTION
## 概要
#34 の修正漏れ修正

## 関連Issue

## 変更内容
- 動画情報取得処理に引数をつけてもタグが絞られないバグを修正

## 動作確認
- ローカルで実行して確認

## 影響範囲

## 補足