### PR TITLE
二次創作データベースの作成

### DIFF
--- a/2026spring/backend/config/settings.yml
+++ b/2026spring/backend/config/settings.yml
@@ -27,6 +27,13 @@ spreadsheets:
     name: "note_list_2025autumn"
     list_sheet: "list"
 
+  fanfic_list:
+    name: "fanfic_list_2025autumn"
+
+  forms_result_fanfic:
+    name: "Forms_result_fanfic_2025autumn"
+    sheet: "シート1"
+
 vote_grouping:
   random_seed: 42
   group_size: 3

--- a/2026spring/backend/lib/niconico.py
+++ b/2026spring/backend/lib/niconico.py
@@ -1,3 +1,4 @@
+import re
 from bs4 import BeautifulSoup
 import xml.etree.ElementTree as ET
 import requests
@@ -164,3 +165,25 @@ def attach_username_and_thumbnail(videos):
             video["thumbnailUrl"] = get_thumbnail_url(video_id)
 
     return videos
+
+
+def fetch_single_video(url, fields):
+
+    m = re.search(r"(sm\d+)", url)
+    if not m:
+        return None
+
+    video_id = m.group(1)
+
+    api = f"https://ext.nicovideo.jp/api/getthumbinfo/{video_id}"
+
+    res = requests.get(api)
+    res.raise_for_status()
+
+    root = ET.fromstring(res.text)
+
+    def get(tag):
+        el = root.find(f".//{tag}")
+        return el.text if el is not None else None
+
+    return {f: get(f) for f in fields}

--- a/2026spring/backend/lib/sheet_client.py
+++ b/2026spring/backend/lib/sheet_client.py
@@ -96,3 +96,36 @@ def fetch_sheet_data(worksheet) -> list[dict]:
     スプレッドシートの内容を list[dict] で取得
     """
     return worksheet.get_all_records()
+
+
+def build_video_index(
+    spreadsheet_name: str,
+    credentials_path: str,
+    target_sheets: list[str] = ["rookie", "op", "ex"],
+) -> dict:
+    """
+    スプレッドシート全体を読み込んで
+    {動画ID: {"タイトル": ..., "投稿者名": ...}} の辞書を作成
+    """
+
+    gc = gspread.service_account(filename=credentials_path)
+    sh = gc.open(spreadsheet_name)
+
+    video_index = {}
+
+    for sheet_name in target_sheets:
+        try:
+            worksheet = sh.worksheet(sheet_name)
+        except gspread.exceptions.WorksheetNotFound:
+            continue
+
+        records = worksheet.get_all_records()
+
+        for row in records:
+            video_id = str(row.get("動画ID"))
+            video_index[video_id] = {
+                "タイトル": row.get("タイトル"),
+                "投稿者名": row.get("投稿者名"),
+            }
+
+    return video_index

--- a/2026spring/backend/lib/youtube.py
+++ b/2026spring/backend/lib/youtube.py
@@ -1,0 +1,13 @@
+import requests
+
+
+def fetch_single_video(url, fields):
+    endpoint = "https://www.youtube.com/oembed"
+    params = {"url": url, "format": "json"}
+
+    res = requests.get(endpoint, params=params)
+    res.raise_for_status()
+
+    data = res.json()
+
+    return {f: data.get(f) for f in fields}

--- a/2026spring/backend/scripts/fetch_fanfic.py
+++ b/2026spring/backend/scripts/fetch_fanfic.py
@@ -1,0 +1,177 @@
+import os
+import re
+import requests
+from bs4 import BeautifulSoup
+from collections import defaultdict
+import xml.etree.ElementTree as ET
+
+from lib import utils
+from lib import sheet_client
+from lib import niconico
+from lib import youtube
+
+
+HEADERS = {"User-Agent": "Mozilla/5.0"}
+
+
+# ------------------------
+# 共通：OGP取得
+# ------------------------
+def fetch_ogp(url):
+    res = requests.get(url, headers=HEADERS, timeout=10)
+    res.raise_for_status()
+
+    soup = BeautifulSoup(res.text, "html.parser")
+
+    def get(prop, attr="property"):
+        tag = soup.find("meta", attrs={attr: prop})
+        return tag["content"] if tag and tag.get("content") else None
+
+    data = {
+        "title": get("og:title"),
+        "description": get("og:description"),
+        "image": get("og:image"),
+    }
+
+    # fallback
+    if not data["title"]:
+        data["title"] = get("twitter:title", "name")
+    if not data["description"]:
+        data["description"] = get("twitter:description", "name")
+    if not data["image"]:
+        data["image"] = get("twitter:image", "name")
+
+    return data
+
+
+# ------------------------
+# ニコニコ動画
+# ------------------------
+def fetch_niconico(url):
+    fields = [
+        "title",
+        "description",
+        "thumbnail_url",
+    ]
+    data = niconico.fetch_single_video(url, fields)
+    data["image"] = data.pop("thumbnail_url")
+
+    return data
+
+
+# ------------------------
+# YouTube
+# ------------------------
+def fetch_youtube(url):
+    fields = [
+        "title",
+        "description",
+        "thumbnail_url",
+    ]
+    data = youtube.fetch_single_video(url, fields)
+    data["image"] = data.pop("thumbnail_url")
+
+    return data
+
+
+# ------------------------
+# X
+# ------------------------
+def fetch_x(url):
+    # Xはスクレイピングを用いずに情報の取得が難しそうなため、取得しない
+
+    return {
+        "title": None,
+        "description": None,
+        "image": None,
+    }
+
+
+# ------------------------
+# サービス振り分け
+# ------------------------
+def fetch_by_service(service, url):
+    if service == "ニコニコ動画":
+        return fetch_niconico(url)
+    elif service == "YouTube":
+        return fetch_youtube(url)
+    elif service == "X":
+        return fetch_x(url)
+    else:
+        return None
+
+
+# ------------------------
+# メイン処理
+# ------------------------
+def main():
+
+    config = utils.load_config()
+    spreadsheet_name = config["spreadsheets"]["fanfic_list"]["name"]
+    input_spreadsheet_name = config["spreadsheets"]["forms_result_fanfic"]["name"]
+    input_sheet_name = config["spreadsheets"]["forms_result_fanfic"]["sheet"]
+
+    credentials_path = os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
+
+    # 入力取得
+    input_ws = sheet_client.connect_sheet(
+        credentials_path, input_spreadsheet_name, input_sheet_name
+    )
+    rows = sheet_client.fetch_sheet_data(input_ws)
+    print(f"total: {len(rows)} items")
+
+    grouped = defaultdict(list)
+
+    for row in rows:
+        category = row.get("分類")
+        author = row.get("投稿者名")
+        service = row.get("投稿先")
+        title_input = row.get("タイトル")
+        description_input = row.get("コメント")
+        image_input = row.get("画像URL")
+        url = row.get("URL")
+
+        if not url or not service or not category:
+            continue
+
+        try:
+            meta = fetch_by_service(service, url)
+
+            if not meta:
+                continue
+
+            # --- タイトル・コメント・画像URL ---
+            if service == "X":
+                title = title_input  # 入力をそのまま
+                description = description_input
+                image = image_input
+            else:
+                title = meta["title"]
+                description = meta["description"]
+                image = meta["image"]
+
+            grouped[category].append(
+                {
+                    "タイトル": title or "",
+                    "投稿者名": author or "",
+                    "コメント": description or "",
+                    "投稿先": service,
+                    "URL": url,
+                    "画像URL": image or "",
+                }
+            )
+
+        except Exception as e:
+            print(f"error: {url} -> {e}")
+
+    # ------------------------
+    # シート書き込み
+    # ------------------------
+    for category, data in grouped.items():
+        print(f"{category}: {len(data)} items")
+        ws = sheet_client.connect_sheet(credentials_path, spreadsheet_name, category)
+        sheet_client.update_sheet(ws, data)
+
+
+if __name__ == "__main__":
+    main()

--- a/2026spring/backend/scripts/fetch_fanfic.py
+++ b/2026spring/backend/scripts/fetch_fanfic.py
@@ -102,6 +102,56 @@ def fetch_by_service(service, url):
 
 
 # ------------------------
+# 元動画情報取得
+# ------------------------
+def extract_video_id(url: str) -> str | None:
+    pattern = r"(sm\d+|nm\d+|so\d+)"
+    match = re.search(pattern, url)
+    return match.group(1) if match else None
+
+
+def find_videos_info(
+    url_list: list[str], spreadsheet_name: str, credentials_path: str
+) -> list[dict]:
+    """
+    URLリストを受け取り、list[dict]で返す
+    """
+
+    video_index = sheet_client.build_video_index(spreadsheet_name, credentials_path)
+
+    results = []
+
+    for url in url_list:
+        video_id = extract_video_id(url)
+
+        if video_id and video_id in video_index:
+            results.append(video_index[video_id])
+        else:
+            results.append({"タイトル": None, "投稿者名": None})
+
+    return results
+
+
+def rename_key(rows: list[dict]):
+    return rows
+
+
+def deduplicate_by_url(data: list[dict]) -> list[dict]:
+    """
+    URLをキーに重複削除（後ろを残す）
+    """
+
+    url_map = {}
+
+    for item in data:
+        url = item.get("二次創作作品URL")
+        if url is not None:
+            url_map[url] = item  # 後ろの要素で上書き
+
+    return list(url_map.values())
+
+
+# ------------------------
 # メイン処理
 # ------------------------
 def main():
@@ -110,6 +160,7 @@ def main():
     spreadsheet_name = config["spreadsheets"]["fanfic_list"]["name"]
     input_spreadsheet_name = config["spreadsheets"]["forms_result_fanfic"]["name"]
     input_sheet_name = config["spreadsheets"]["forms_result_fanfic"]["sheet"]
+    video_catalog_spreadsheet_name = config["spreadsheets"]["video_catalog"]["name"]
 
     credentials_path = os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
 
@@ -118,18 +169,33 @@ def main():
         credentials_path, input_spreadsheet_name, input_sheet_name
     )
     rows = sheet_client.fetch_sheet_data(input_ws)
+    rows = rename_key(rows)
+    print(f"total: {len(rows)} items")
+
+    # 重複削除
+    rows = deduplicate_by_url(rows)
     print(f"total: {len(rows)} items")
 
     grouped = defaultdict(list)
 
-    for row in rows:
+    # 元動画情報取得
+    rows_org = find_videos_info(
+        [row.get("元動画URL") for row in rows],
+        video_catalog_spreadsheet_name,
+        credentials_path,
+    )
+
+    # 二次創作作品情報取得
+    for row, row_org in zip(rows, rows_org):
         category = row.get("分類")
-        author = row.get("投稿者名")
+        author = row.get("二次創作者名")
         service = row.get("投稿先")
         title_input = row.get("タイトル")
-        description_input = row.get("コメント")
         image_input = row.get("画像URL")
-        url = row.get("URL")
+        url = row.get("二次創作作品URL")
+        url_org = row.get("元動画URL")
+        title_org = row_org.get("タイトル")
+        author_org = row_org.get("投稿者名")
 
         if not url or not service or not category:
             continue
@@ -143,30 +209,28 @@ def main():
             # --- タイトル・コメント・画像URL ---
             if service == "X":
                 title = title_input  # 入力をそのまま
-                description = description_input
                 image = image_input
             else:
                 title = meta["title"]
-                description = meta["description"]
                 image = meta["image"]
 
             grouped[category].append(
                 {
                     "タイトル": title or "",
-                    "投稿者名": author or "",
-                    "コメント": description or "",
+                    "二次創作者名": author or "",
                     "投稿先": service,
-                    "URL": url,
+                    "二次創作作品URL": url,
                     "画像URL": image or "",
+                    "元動画URL": url_org or "",
+                    "元動画タイトル": title_org or "",
+                    "元動画投稿者名": author_org or "",
                 }
             )
 
         except Exception as e:
             print(f"error: {url} -> {e}")
 
-    # ------------------------
     # シート書き込み
-    # ------------------------
     for category, data in grouped.items():
         print(f"{category}: {len(data)} items")
         ws = sheet_client.connect_sheet(credentials_path, spreadsheet_name, category)


### PR DESCRIPTION
## 概要
二次創作データベース作成機能

## 関連Issue
- Closes #40 

## 変更内容
- 二次創作Formsから、二次創作データベースを作成する機能を追加（fetch_fanfic.py）

## 動作確認
- ローカルで実行して確認

## 影響範囲

## 補足
- Note記事については別で情報を集める想定（すでにデータベース作成機能実装されている認識）
- Formsで以下の情報を集める想定
   | カラム名 | 内容 | 値の制約など |
   | --- | --- | --- |
   | 分類 | 二次創作の種類 | イラスト/歌ってみた/アレンジ/紹介配信/その他 |
   | 投稿者名 | 投稿者名 | |
   | 投稿先 | 投稿先のサービス | ニコニコ動画/YouTube/X |
   | タイトル | Web掲載時のタイトル。Xポストだとタイトルがないので記入してもらう想定 | |
   | コメント | Web掲載時に付記する情報。Xポスト、YouTubeだと概要欄情報等が取れないので記入してもらう想定 | |
   | 画像URL | Web掲載時に表示する画像のURL。Xポストだと画像がないので記入してもらう想定 | 空欄でも可 |
   | URL | 作品のURL | |
   
   「コメント」はX・YouTubeのときのみ、「タイトル」「画像URL」はXのときのみ記入してもらう想定。「投稿先」の回答によって「タイトル」「コメント」「画像URL」の質問の表示・非表示を変えられると良い。
- 上記の情報が入ったスプレッドシートから、「分類」でシート分けして、以下の情報が入ったスプレッドシートを作成する。
   | カラム名 | 内容 |
   | --- | --- |
   | タイトル | Web掲載時タイトル。YouTube・ニコニコ動画の場合は動画タイトル |
   | コメント | Web掲載に付記する情報。ニコニコ動画の場合は概要欄 |
   | 投稿先 | 投稿先のサービス |
   | URL | 作品のURL |
   | 画像URL | Web掲載時に表示する画像のURL。YouTube・ニコニコ動画の場合はサムネイル |

- 議論がありそうな部分
  - 現状の実装だとXから何も情報が取得できず（スクレイピングをすればやりようはありそうだがグレー）、YouTubeから概要欄が取得できない（こちらも同様）。取得できない情報はFormsで集める際に記入してもらうしかないか
     特に、Xのポストだと画像URLも記入してもらわないといけない（イラストでない場合は画像はないので空欄になる）
  - 「コメント」の欄はニコニコ動画からしか取得できないなら、Webに掲載しなくてもいいかも
  - 想定する分類は イラスト/歌ってみた/アレンジ/紹介配信/その他 で良いか
  - 想定するサービスは ニコニコ動画/YouTube/X で良いか。ニコニコ動画、YouTube以外はXのポストに貼ってもらって載せることになる。





