### PR TITLE
二次創作一覧作成の一連のプロセス作成

### DIFF
--- a/.github/workflows/2026spring_fetch_fanfic.yml
+++ b/.github/workflows/2026spring_fetch_fanfic.yml
@@ -1,0 +1,41 @@
+name: 2026spring Fetch Fanfic
+
+on:
+  workflow_dispatch:  # 手動実行
+  schedule:
+    #- cron: '0 * * * *'  # 毎時実行
+    #- cron: '0 */3 * * *' # 3時間おき実行
+    - cron: '0 */6 * * *' # 6時間おき実行
+    #- cron: '0 15 * * *' # 毎日実行（日本時間0時）
+
+jobs:
+  run-script:
+    runs-on: ubuntu-latest
+
+    env:
+      GOOGLE_APPLICATION_CREDENTIALS: credentials.json
+
+    defaults:
+      run:
+        working-directory: 2026spring/backend
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+
+      - name: Create credentials.json
+        run: |
+          echo '${{ secrets.GOOGLE_CREDENTIALS }}' > credentials.json
+
+      - name: Run script
+        run: |
+          python -m scripts.fetch_fanfic

--- a/.github/workflows/2026spring_fetch_fanfic_forms_result.yml
+++ b/.github/workflows/2026spring_fetch_fanfic_forms_result.yml
@@ -1,0 +1,41 @@
+name: 2026spring Fetch Fanfic Forms Result
+
+on:
+  workflow_dispatch:  # 手動実行
+  schedule:
+    #- cron: '0 * * * *'  # 毎時実行
+    #- cron: '0 */3 * * *' # 3時間おき実行
+    - cron: '0 */6 * * *' # 6時間おき実行
+    #- cron: '0 15 * * *' # 毎日実行（日本時間0時）
+
+jobs:
+  run-script:
+    runs-on: ubuntu-latest
+
+    env:
+      GOOGLE_APPLICATION_CREDENTIALS: credentials.json
+
+    defaults:
+      run:
+        working-directory: 2026spring/backend
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+
+      - name: Create credentials.json
+        run: |
+          echo '${{ secrets.GOOGLE_CREDENTIALS }}' > credentials.json
+
+      - name: Run script
+        run: |
+          python -m scripts.fetch_fanfic_forms_result

--- a/2026spring/backend/config/settings.yml
+++ b/2026spring/backend/config/settings.yml
@@ -31,7 +31,7 @@ spreadsheets:
     name: "fanfic_list_2025autumn"
 
   forms_result_fanfic:
-    name: "Forms_result_fanfic_2025autumn"
+    name: "二次創作作品提出フォーム回答_2025秋"
     forms_result: "Forms_result"
     for_check: "二次創作作品情報確認用"
 

--- a/2026spring/backend/config/settings.yml
+++ b/2026spring/backend/config/settings.yml
@@ -32,7 +32,8 @@ spreadsheets:
 
   forms_result_fanfic:
     name: "Forms_result_fanfic_2025autumn"
-    sheet: "シート1"
+    forms_result: "Forms_result"
+    for_check: "二次創作作品情報確認用"
 
 vote_grouping:
   random_seed: 42

--- a/2026spring/backend/lib/niconico.py
+++ b/2026spring/backend/lib/niconico.py
@@ -2,6 +2,7 @@ import re
 from bs4 import BeautifulSoup
 import xml.etree.ElementTree as ET
 import requests
+import json
 
 
 def fetch_all_videos(tag, limit=100):

--- a/2026spring/backend/lib/niconico.py
+++ b/2026spring/backend/lib/niconico.py
@@ -2,7 +2,6 @@ import re
 from bs4 import BeautifulSoup
 import xml.etree.ElementTree as ET
 import requests
-import json
 
 
 def fetch_all_videos(tag, limit=100):

--- a/2026spring/backend/lib/youtube.py
+++ b/2026spring/backend/lib/youtube.py
@@ -10,4 +10,16 @@ def fetch_single_video(url, fields):
 
     data = res.json()
 
-    return {f: data.get(f) for f in fields}
+    def get(field):
+        if field == "title":
+            return data.get("title")
+
+        if field in ["author_name", "channel_title"]:
+            return data.get("author_name")
+
+        if field == "thumbnail_url":
+            return data.get("thumbnail_url")
+
+        return None
+
+    return {f: get(f) for f in fields}

--- a/2026spring/backend/scripts/fetch_fanfic.py
+++ b/2026spring/backend/scripts/fetch_fanfic.py
@@ -7,133 +7,6 @@ import xml.etree.ElementTree as ET
 
 from lib import utils
 from lib import sheet_client
-from lib import niconico
-from lib import youtube
-
-
-HEADERS = {"User-Agent": "Mozilla/5.0"}
-
-
-# ------------------------
-# 共通：OGP取得
-# ------------------------
-def fetch_ogp(url):
-    res = requests.get(url, headers=HEADERS, timeout=10)
-    res.raise_for_status()
-
-    soup = BeautifulSoup(res.text, "html.parser")
-
-    def get(prop, attr="property"):
-        tag = soup.find("meta", attrs={attr: prop})
-        return tag["content"] if tag and tag.get("content") else None
-
-    data = {
-        "title": get("og:title"),
-        "description": get("og:description"),
-        "image": get("og:image"),
-    }
-
-    # fallback
-    if not data["title"]:
-        data["title"] = get("twitter:title", "name")
-    if not data["description"]:
-        data["description"] = get("twitter:description", "name")
-    if not data["image"]:
-        data["image"] = get("twitter:image", "name")
-
-    return data
-
-
-# ------------------------
-# ニコニコ動画
-# ------------------------
-def fetch_niconico(url):
-    fields = [
-        "title",
-        "description",
-        "thumbnail_url",
-    ]
-    data = niconico.fetch_single_video(url, fields)
-    data["image"] = data.pop("thumbnail_url")
-
-    return data
-
-
-# ------------------------
-# YouTube
-# ------------------------
-def fetch_youtube(url):
-    fields = [
-        "title",
-        "description",
-        "thumbnail_url",
-    ]
-    data = youtube.fetch_single_video(url, fields)
-    data["image"] = data.pop("thumbnail_url")
-
-    return data
-
-
-# ------------------------
-# X
-# ------------------------
-def fetch_x(url):
-    # Xはスクレイピングを用いずに情報の取得が難しそうなため、取得しない
-
-    return {
-        "title": None,
-        "description": None,
-        "image": None,
-    }
-
-
-# ------------------------
-# サービス振り分け
-# ------------------------
-def fetch_by_service(service, url):
-    if service == "ニコニコ動画":
-        return fetch_niconico(url)
-    elif service == "YouTube":
-        return fetch_youtube(url)
-    elif service == "X":
-        return fetch_x(url)
-    else:
-        return None
-
-
-# ------------------------
-# 元動画情報取得
-# ------------------------
-def extract_video_id(url: str) -> str | None:
-    pattern = r"(sm\d+|nm\d+|so\d+)"
-    match = re.search(pattern, url)
-    return match.group(1) if match else None
-
-
-def find_videos_info(
-    url_list: list[str], spreadsheet_name: str, credentials_path: str
-) -> list[dict]:
-    """
-    URLリストを受け取り、list[dict]で返す
-    """
-
-    video_index = sheet_client.build_video_index(spreadsheet_name, credentials_path)
-
-    results = []
-
-    for url in url_list:
-        video_id = extract_video_id(url)
-
-        if video_id and video_id in video_index:
-            results.append(video_index[video_id])
-        else:
-            results.append({"タイトル": None, "投稿者名": None})
-
-    return results
-
-
-def rename_key(rows: list[dict]):
-    return rows
 
 
 def deduplicate_by_url(data: list[dict]) -> list[dict]:
@@ -151,6 +24,28 @@ def deduplicate_by_url(data: list[dict]) -> list[dict]:
     return list(url_map.values())
 
 
+def remove_invalid(data: list[dict]) -> list[dict]:
+    """
+    使用しない行・列を削除
+    """
+
+    valid_data = []
+    for item in data:
+        is_valid = item["掲載可否"]
+        if not is_valid or is_valid in ["否", "不可", "×", "x"]:
+            continue
+
+        valid_data.append(
+            {
+                k: v
+                for k, v in item.items()
+                if k not in ["タイムスタンプ", "メールアドレス", "掲載可否", "メモ"]
+            }
+        )
+
+    return valid_data
+
+
 # ------------------------
 # メイン処理
 # ------------------------
@@ -159,8 +54,7 @@ def main():
     config = utils.load_config()
     spreadsheet_name = config["spreadsheets"]["fanfic_list"]["name"]
     input_spreadsheet_name = config["spreadsheets"]["forms_result_fanfic"]["name"]
-    input_sheet_name = config["spreadsheets"]["forms_result_fanfic"]["sheet"]
-    video_catalog_spreadsheet_name = config["spreadsheets"]["video_catalog"]["name"]
+    input_sheet_name = config["spreadsheets"]["forms_result_fanfic"]["for_check"]
 
     credentials_path = os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
 
@@ -169,66 +63,26 @@ def main():
         credentials_path, input_spreadsheet_name, input_sheet_name
     )
     rows = sheet_client.fetch_sheet_data(input_ws)
-    rows = rename_key(rows)
     print(f"total: {len(rows)} items")
 
     # 重複削除
     rows = deduplicate_by_url(rows)
+
+    # 掲載不可のものを削除
+    rows = remove_invalid(rows)
     print(f"total: {len(rows)} items")
 
     grouped = defaultdict(list)
 
-    # 元動画情報取得
-    rows_org = find_videos_info(
-        [row.get("元動画URL") for row in rows],
-        video_catalog_spreadsheet_name,
-        credentials_path,
-    )
-
     # 二次創作作品情報取得
-    for row, row_org in zip(rows, rows_org):
-        category = row.get("分類")
-        author = row.get("二次創作者名")
-        service = row.get("投稿先")
-        title_input = row.get("タイトル")
-        image_input = row.get("画像URL")
-        url = row.get("二次創作作品URL")
-        url_org = row.get("元動画URL")
-        title_org = row_org.get("タイトル")
-        author_org = row_org.get("投稿者名")
+    for row in rows:
+        url = row["二次創作作品URL"]
+        category = row["分類"]
 
-        if not url or not service or not category:
+        if not url or not category:
             continue
 
-        try:
-            meta = fetch_by_service(service, url)
-
-            if not meta:
-                continue
-
-            # --- タイトル・コメント・画像URL ---
-            if service == "X":
-                title = title_input  # 入力をそのまま
-                image = image_input
-            else:
-                title = meta["title"]
-                image = meta["image"]
-
-            grouped[category].append(
-                {
-                    "タイトル": title or "",
-                    "二次創作者名": author or "",
-                    "投稿先": service,
-                    "二次創作作品URL": url,
-                    "画像URL": image or "",
-                    "元動画URL": url_org or "",
-                    "元動画タイトル": title_org or "",
-                    "元動画投稿者名": author_org or "",
-                }
-            )
-
-        except Exception as e:
-            print(f"error: {url} -> {e}")
+        grouped[category].append({k: v for k, v in row.items() if k not in ["分類"]})
 
     # シート書き込み
     for category, data in grouped.items():

--- a/2026spring/backend/scripts/fetch_fanfic.py
+++ b/2026spring/backend/scripts/fetch_fanfic.py
@@ -61,11 +61,11 @@ def main():
     rows = sheet_client.fetch_sheet_data(input_ws)
     print(f"total: {len(rows)} items")
 
-    # 重複削除
-    rows = deduplicate_by_url(rows)
-
     # 掲載不可のものを削除
     rows = remove_invalid(rows)
+
+    # 重複削除
+    rows = deduplicate_by_url(rows)
     print(f"total: {len(rows)} items")
 
     grouped = defaultdict(list)

--- a/2026spring/backend/scripts/fetch_fanfic.py
+++ b/2026spring/backend/scripts/fetch_fanfic.py
@@ -1,9 +1,5 @@
 import os
-import re
-import requests
-from bs4 import BeautifulSoup
 from collections import defaultdict
-import xml.etree.ElementTree as ET
 
 from lib import utils
 from lib import sheet_client

--- a/2026spring/backend/scripts/fetch_fanfic_forms_result.py
+++ b/2026spring/backend/scripts/fetch_fanfic_forms_result.py
@@ -2,8 +2,6 @@ import os
 import re
 import requests
 from bs4 import BeautifulSoup
-from collections import defaultdict
-import xml.etree.ElementTree as ET
 
 from lib import utils
 from lib import sheet_client

--- a/2026spring/backend/scripts/fetch_fanfic_forms_result.py
+++ b/2026spring/backend/scripts/fetch_fanfic_forms_result.py
@@ -1,0 +1,239 @@
+import os
+import re
+import requests
+from bs4 import BeautifulSoup
+from collections import defaultdict
+import xml.etree.ElementTree as ET
+
+from lib import utils
+from lib import sheet_client
+from lib import niconico
+from lib import youtube
+
+
+HEADERS = {"User-Agent": "Mozilla/5.0"}
+
+
+# ------------------------
+# 共通：OGP取得
+# ------------------------
+def fetch_ogp(url):
+    res = requests.get(url, headers=HEADERS, timeout=10)
+    res.raise_for_status()
+
+    soup = BeautifulSoup(res.text, "html.parser")
+
+    def get(prop, attr="property"):
+        tag = soup.find("meta", attrs={attr: prop})
+        return tag["content"] if tag and tag.get("content") else None
+
+    data = {
+        "title": get("og:title"),
+        "description": get("og:description"),
+        "image": get("og:image"),
+    }
+
+    # fallback
+    if not data["title"]:
+        data["title"] = get("twitter:title", "name")
+    if not data["description"]:
+        data["description"] = get("twitter:description", "name")
+    if not data["image"]:
+        data["image"] = get("twitter:image", "name")
+
+    return data
+
+
+# ------------------------
+# ニコニコ動画
+# ------------------------
+def fetch_niconico(url):
+    fields = [
+        "title",
+        "description",
+        "thumbnail_url",
+    ]
+    data = niconico.fetch_single_video(url, fields)
+    data["image"] = data.pop("thumbnail_url")
+
+    return data
+
+
+# ------------------------
+# YouTube
+# ------------------------
+def fetch_youtube(url):
+    fields = [
+        "title",
+        "description",
+        "thumbnail_url",
+    ]
+    data = youtube.fetch_single_video(url, fields)
+    data["image"] = data.pop("thumbnail_url")
+
+    return data
+
+
+# ------------------------
+# その他（Xなど）
+# ------------------------
+def fetch_others(url):
+    # Xはスクレイピングを用いずに情報の取得が難しそうなため、取得しない
+
+    return {
+        "title": None,
+        "description": None,
+        "image": None,
+    }
+
+
+# ------------------------
+# サービス振り分け
+# ------------------------
+def fetch_by_service(service, url):
+    if service == "ニコニコ動画":
+        return fetch_niconico(url)
+    elif service == "YouTube":
+        return fetch_youtube(url)
+    elif service == "その他":
+        return fetch_others(url)
+    else:
+        return None
+
+
+# ------------------------
+# 元動画情報取得
+# ------------------------
+def extract_video_id(url: str) -> str | None:
+    pattern = r"(sm\d+|nm\d+|so\d+)"
+    match = re.search(pattern, url)
+    return match.group(1) if match else None
+
+
+def find_videos_info(
+    url_list: list[str], spreadsheet_name: str, credentials_path: str
+) -> list[dict]:
+    """
+    URLリストを受け取り、list[dict]で返す
+    """
+
+    video_index = sheet_client.build_video_index(spreadsheet_name, credentials_path)
+
+    results = []
+
+    for url in url_list:
+        video_id = extract_video_id(url)
+
+        if video_id and video_id in video_index:
+            results.append(video_index[video_id])
+        else:
+            results.append({"タイトル": None, "投稿者名": None})
+
+    return results
+
+
+# ------------------------
+# メイン処理
+# ------------------------
+def main():
+    table_keys = {
+        "timestamp": "タイムスタンプ",
+        "mail": "メールアドレス",
+        "category": "分類",
+        "release_time": "配信日時",
+        "author": "二次創作者活動名",
+        "service": "投稿先サービス",
+        "url": "二次創作作品URL",
+        "title": "タイトル",
+        "image": "画像URL",
+        "org_url": "元作品URL",
+    }
+
+    config = utils.load_config()
+    spreadsheet_name = config["spreadsheets"]["forms_result_fanfic"]["name"]
+    input_sheet_name = config["spreadsheets"]["forms_result_fanfic"]["forms_result"]
+    output_sheet_name = config["spreadsheets"]["forms_result_fanfic"]["for_check"]
+    video_catalog_spreadsheet_name = config["spreadsheets"]["video_catalog"]["name"]
+
+    credentials_path = os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
+
+    # 入力取得
+    input_ws = sheet_client.connect_sheet(
+        credentials_path, spreadsheet_name, input_sheet_name
+    )
+    src_data = sheet_client.fetch_sheet_data(input_ws)
+
+    output_ws = sheet_client.connect_sheet(
+        credentials_path, spreadsheet_name, output_sheet_name
+    )
+    dest_data = sheet_client.fetch_sheet_data(output_ws)
+
+    # 転記先に既にあるキーを集合で持つ
+    key_columns = ["タイムスタンプ", "メールアドレス"]
+    existing_keys = {tuple(str(row.get(k)) for k in key_columns) for row in dest_data}
+
+    # 差分抽出
+    new_rows = []
+    for row in src_data:
+        key = tuple(str(row.get(k)) for k in key_columns)
+        if key and key not in existing_keys:
+            new_rows.append(row)
+
+    print(f"total: {len(new_rows)} items")
+
+    # 元動画情報取得
+    rows_org = find_videos_info(
+        [row.get(table_keys["org_url"]) for row in new_rows],
+        video_catalog_spreadsheet_name,
+        credentials_path,
+    )
+
+    # 二次創作作品情報取得
+    update_rows = []
+    for row, row_org in zip(new_rows, rows_org):
+        items = {k: row.get(v) for k, v in table_keys.items()}
+        org_title = row_org.get("タイトル")
+        org_author = row_org.get("投稿者名")
+
+        url = items["url"]
+        service = items["service"]
+        category = items["category"]
+
+        if not url or not service or not category:
+            continue
+
+        try:
+            meta = fetch_by_service(service, url)
+            if not meta:
+                meta = {"title": None, "image": None}
+
+            # タイトル・画像URL
+            if service != "その他":
+                items["title"] = meta["title"]
+                items["image"] = meta["image"]
+
+            row = {table_keys[k]: v for k, v in items.items()}
+            row["元作品タイトル"] = org_title or ""
+            row["元作品投稿者名"] = org_author or ""
+            row["掲載可否"] = 0
+
+            update_rows.append(row)
+
+        except Exception as e:
+            print(f"error: {url} -> {e}")
+
+    # 追加
+    if len(dest_data) == 0:
+        sheet_client.update_sheet(output_ws, update_rows)
+        print(f"{len(update_rows)} items")
+        return
+
+    if update_rows:
+        sheet_client.append_sheet(output_ws, update_rows)
+        print(f"{len(update_rows)} items")
+    else:
+        print("No items")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 概要
二次創作一覧作成の一連のプロセスを作成する

## 関連Issue
- Closes #47 

## 変更内容
- 二次創作情報提出Formsの修正
- Formsの回答シートから内容確認用シートへの転記処理作成
- 二次創作内容確認シートから二次創作一覧シートへの転記処理作成
- GitHub Actionsでの自動化作成 

## 動作確認
- ローカルで実行して動作確認

## 影響範囲

## 補足