### PR TITLE
OP楽曲一覧ページ作成

### DIFF
--- a/2026spring/frontend/src/app/api/submissions/songs/extra/route.ts
+++ b/2026spring/frontend/src/app/api/submissions/songs/extra/route.ts
@@ -1,0 +1,76 @@
+// app/api/videos/op/route.ts
+
+import { fetchVideosSheet } from "@/lib/fetchSheet";
+import { CONFIG } from "@/config/config";
+
+/* =========================
+   キャッシュ
+========================= */
+type Cache = {
+  data: any;
+  timestamp: number;
+};
+
+let cache: Cache | null = null;
+const CACHE_TTL = 1000 * 60 * 5; // 5分
+
+/* =========================
+   日付パース
+========================= */
+function parseDate(dateStr?: string) {
+  if (!dateStr) return 0;
+
+  const cleaned = dateStr.replace(/^'/, "").trim();
+
+  const match = cleaned.match(
+    /^(\d{4})\/(\d{1,2})\/(\d{1,2})\s*(\d{1,2})?:?(\d{2})?/
+  );
+
+  if (!match) return 0;
+
+  const [, y, m, d, h = "0", min = "0"] = match;
+
+  return new Date(
+    Number(y),
+    Number(m) - 1,
+    Number(d),
+    Number(h),
+    Number(min)
+  ).getTime();
+}
+
+/* =========================
+   API
+========================= */
+export async function GET() {
+  try {
+    const now = Date.now();
+
+    // ✔ キャッシュが有効なら返す
+    if (cache && now - cache.timestamp < CACHE_TTL) {
+      return Response.json(cache.data);
+    }
+
+    // ✔ Sheets取得
+    const items = await fetchVideosSheet(CONFIG.videosheets.ex.name);
+
+    const videos = items
+      .filter((item) => item.videoUrl)
+      .sort(
+        (a, b) => parseDate(b.publishedAt) - parseDate(a.publishedAt)
+      );
+
+    // ✔ キャッシュ更新
+    cache = {
+      data: videos,
+      timestamp: now,
+    };
+
+    return Response.json(videos);
+  } catch {
+    return new Response(
+      JSON.stringify({ error: "Failed to fetch videos" }),
+      { status: 500 }
+    );
+  }
+}

--- a/2026spring/frontend/src/app/api/submissions/songs/opening/route.ts
+++ b/2026spring/frontend/src/app/api/submissions/songs/opening/route.ts
@@ -1,0 +1,76 @@
+// app/api/videos/op/route.ts
+
+import { fetchVideosSheet } from "@/lib/fetchSheet";
+import { CONFIG } from "@/config/config";
+
+/* =========================
+   キャッシュ
+========================= */
+type Cache = {
+  data: any;
+  timestamp: number;
+};
+
+let cache: Cache | null = null;
+const CACHE_TTL = 1000 * 60 * 5; // 5分
+
+/* =========================
+   日付パース
+========================= */
+function parseDate(dateStr?: string) {
+  if (!dateStr) return 0;
+
+  const cleaned = dateStr.replace(/^'/, "").trim();
+
+  const match = cleaned.match(
+    /^(\d{4})\/(\d{1,2})\/(\d{1,2})\s*(\d{1,2})?:?(\d{2})?/
+  );
+
+  if (!match) return 0;
+
+  const [, y, m, d, h = "0", min = "0"] = match;
+
+  return new Date(
+    Number(y),
+    Number(m) - 1,
+    Number(d),
+    Number(h),
+    Number(min)
+  ).getTime();
+}
+
+/* =========================
+   API
+========================= */
+export async function GET() {
+  try {
+    const now = Date.now();
+
+    // ✔ キャッシュが有効なら返す
+    if (cache && now - cache.timestamp < CACHE_TTL) {
+      return Response.json(cache.data);
+    }
+
+    // ✔ Sheets取得
+    const items = await fetchVideosSheet(CONFIG.videosheets.op.name);
+
+    const videos = items
+      .filter((item) => item.videoUrl)
+      .sort(
+        (a, b) => parseDate(b.publishedAt) - parseDate(a.publishedAt)
+      );
+
+    // ✔ キャッシュ更新
+    cache = {
+      data: videos,
+      timestamp: now,
+    };
+
+    return Response.json(videos);
+  } catch {
+    return new Response(
+      JSON.stringify({ error: "Failed to fetch videos" }),
+      { status: 500 }
+    );
+  }
+}

--- a/2026spring/frontend/src/app/api/submissions/songs/rookie/route.ts
+++ b/2026spring/frontend/src/app/api/submissions/songs/rookie/route.ts
@@ -1,0 +1,76 @@
+// app/api/videos/op/route.ts
+
+import { fetchVideosSheet } from "@/lib/fetchSheet";
+import { CONFIG } from "@/config/config";
+
+/* =========================
+   キャッシュ
+========================= */
+type Cache = {
+  data: any;
+  timestamp: number;
+};
+
+let cache: Cache | null = null;
+const CACHE_TTL = 1000 * 60 * 5; // 5分
+
+/* =========================
+   日付パース
+========================= */
+function parseDate(dateStr?: string) {
+  if (!dateStr) return 0;
+
+  const cleaned = dateStr.replace(/^'/, "").trim();
+
+  const match = cleaned.match(
+    /^(\d{4})\/(\d{1,2})\/(\d{1,2})\s*(\d{1,2})?:?(\d{2})?/
+  );
+
+  if (!match) return 0;
+
+  const [, y, m, d, h = "0", min = "0"] = match;
+
+  return new Date(
+    Number(y),
+    Number(m) - 1,
+    Number(d),
+    Number(h),
+    Number(min)
+  ).getTime();
+}
+
+/* =========================
+   API
+========================= */
+export async function GET() {
+  try {
+    const now = Date.now();
+
+    // ✔ キャッシュが有効なら返す
+    if (cache && now - cache.timestamp < CACHE_TTL) {
+      return Response.json(cache.data);
+    }
+
+    // ✔ Sheets取得
+    const items = await fetchVideosSheet(CONFIG.videosheets.rookie.name);
+
+    const videos = items
+      .filter((item) => item.videoUrl)
+      .sort(
+        (a, b) => parseDate(b.publishedAt) - parseDate(a.publishedAt)
+      );
+
+    // ✔ キャッシュ更新
+    cache = {
+      data: videos,
+      timestamp: now,
+    };
+
+    return Response.json(videos);
+  } catch {
+    return new Response(
+      JSON.stringify({ error: "Failed to fetch videos" }),
+      { status: 500 }
+    );
+  }
+}

--- a/2026spring/frontend/src/app/derivative/arrangements/page.tsx
+++ b/2026spring/frontend/src/app/derivative/arrangements/page.tsx
@@ -19,20 +19,16 @@ type Item = {
 ========================= */
 function SkeletonCard() {
   return (
-    <div className="w-[760px] max-w-full rounded-xl bg-white p-4 shadow-sm">
+    <div className="w-full max-w-[760px] rounded-xl bg-white p-4 shadow-sm">
       <div className="flex gap-4 w-full">
-        {/* サムネ */}
-        <div className="w-44 h-28 bg-gray-200 rounded-lg animate-pulse" />
+        <div className="w-32 sm:w-44 h-20 sm:h-28 bg-gray-200 rounded-lg animate-pulse" />
 
-        {/* テキスト */}
         <div className="flex flex-col justify-between flex-1 min-w-0 gap-3">
-          {/* タイトル */}
           <div className="space-y-2">
             <div className="h-5 bg-gray-200 rounded w-3/4 animate-pulse" />
             <div className="h-4 bg-gray-200 rounded w-1/2 animate-pulse" />
           </div>
 
-          {/* メタ */}
           <div className="space-y-2">
             <div className="h-5 bg-gray-200 rounded w-24 animate-pulse" />
             <div className="h-10 bg-gray-200 rounded w-full animate-pulse" />
@@ -48,66 +44,100 @@ function SkeletonCard() {
 ========================= */
 export default function Page() {
   const [data, setData] = useState<Item[]>([]);
+  const [displayData, setDisplayData] = useState<Item[]>([]);
   const [loading, setLoading] = useState(true);
   const [ready, setReady] = useState(false);
+
+  const [searchText, setSearchText] = useState("");
 
   useEffect(() => {
     fetch("/api/derivative/arrangements")
       .then((res) => res.json())
       .then((res) => {
         setData(res);
+        setDisplayData(res);
         setLoading(false);
 
-        // フェードイン用
         setTimeout(() => setReady(true), 50);
       });
   }, []);
 
+  /* =========================
+     検索
+  ========================= */
+  useEffect(() => {
+    let filtered = [...data];
+
+    if (searchText.trim()) {
+      const q = searchText.toLowerCase();
+      filtered = filtered.filter((item) =>
+        (
+          item.title +
+          item.creator +
+          item.originalTitle +
+          item.originalAuthor
+        )
+          .toLowerCase()
+          .includes(q)
+      );
+    }
+
+    setDisplayData(filtered);
+  }, [searchText, data]);
+
   return (
-    <div className="p-6 max-w-4xl mx-auto">
+    <div className="p-4 sm:p-6 flex flex-col items-center">
       {/* ヘッダー */}
-      <div className="text-center mb-10">
-        <h1 className="text-3xl md:text-4xl font-bold">
+      <div className="text-center mb-8 w-full max-w-[760px]">
+        <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold">
           二次創作（アレンジ）
         </h1>
 
-        <p className="text-sm text-gray-600 mt-2">
+        <p className="text-xs sm:text-sm text-gray-600 mt-2">
           「{CONFIG.event.name}」の二次創作アレンジ作品を掲載しています。
         </p>
 
-        <div className="mt-4 border-b border-gray-200 max-w-xl mx-auto" />
+        {/* 下線統一 */}
+        <div className="mt-4 border-b border-gray-200 w-full" />
       </div>
 
-      {/* =========================
-          LOADING (Skeleton)
-      ========================= */}
+      {/* 検索 */}
+      {!loading && (
+        <div className="w-full max-w-[760px] mb-4 flex">
+          <input
+            type="text"
+            placeholder="検索"
+            value={searchText}
+            onChange={(e) => setSearchText(e.target.value)}
+            className="w-40 sm:w-56 border rounded px-2 py-1 text-sm"
+          />
+        </div>
+      )}
+
+      {/* LOADING */}
       {loading && (
-        <div className="flex flex-col gap-6 items-center">
+        <div className="flex flex-col gap-6 items-center w-full">
           {Array.from({ length: 6 }).map((_, i) => (
             <SkeletonCard key={i} />
           ))}
         </div>
       )}
 
-      {/* =========================
-          EMPTY
-      ========================= */}
-      {!loading && data.length === 0 && (
-        <div className="text-center py-20 text-gray-600">
+      {/* EMPTY */}
+      {!loading && displayData.length === 0 && (
+        <div className="text-center py-20 text-gray-600 w-full max-w-[760px]">
           二次創作（アレンジ）はまだありません。
         </div>
       )}
 
-      {/* =========================
-          CONTENT
-      ========================= */}
-      {!loading && data.length > 0 && (
+      {/* CONTENT */}
+      {!loading && displayData.length > 0 && (
         <div
-          className={`flex flex-col gap-6 items-center transition-opacity duration-300 ${
+          className={`flex flex-col gap-4 sm:gap-6 items-center w-full transition-opacity duration-300 ${
             ready ? "opacity-100" : "opacity-0"
           }`}
         >
-          {data.map((item, i) => {
+          {displayData.map((item, i) => {
             const img =
               item.imageUrl?.trim()
                 ? item.imageUrl
@@ -116,14 +146,14 @@ export default function Page() {
             return (
               <div
                 key={i}
-                className="group w-[760px] max-w-full rounded-xl bg-white p-4 shadow-sm hover:shadow-md transition"
+                className="group w-full max-w-[760px] rounded-xl bg-white p-3 sm:p-4 shadow-sm hover:shadow-md transition"
               >
-                <div className="flex gap-4 w-full">
+                <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 w-full">
                   {/* サムネ */}
                   <a
                     href={item.workUrl}
                     target="_blank"
-                    className="w-44 h-28 flex-shrink-0 overflow-hidden rounded-lg"
+                    className="w-full sm:w-44 h-48 sm:h-28 flex-shrink-0 overflow-hidden rounded-lg"
                   >
                     <img
                       src={img}
@@ -133,10 +163,9 @@ export default function Page() {
 
                   {/* テキスト */}
                   <div className="flex flex-col justify-between flex-1 min-w-0">
-                    {/* タイトル */}
                     <div className="min-w-0">
                       <a href={item.workUrl} target="_blank">
-                        <h2 className="text-lg md:text-xl font-bold leading-snug truncate group-hover:underline">
+                        <h2 className="text-base sm:text-lg md:text-xl font-bold leading-snug line-clamp-2 group-hover:underline">
                           {item.title}
                         </h2>
                       </a>
@@ -146,9 +175,7 @@ export default function Page() {
                       </p>
                     </div>
 
-                    {/* メタ */}
                     <div className="mt-3 flex flex-col gap-2 w-full">
-                      {/* 投稿先 */}
                       {item.service && item.service !== "その他" && (
                         <div>
                           <span className="text-xs px-2 py-1 rounded-full bg-gray-100 text-gray-700 inline-block truncate max-w-full">
@@ -157,7 +184,6 @@ export default function Page() {
                         </div>
                       )}
 
-                      {/* Original */}
                       {item.originalTitle && (
                         <div className="bg-gray-50 px-3 py-2 rounded-lg text-xs text-gray-600 w-full min-w-0">
                           <a
@@ -166,7 +192,8 @@ export default function Page() {
                             className="block truncate underline hover:text-gray-800"
                           >
                             {item.originalTitle}
-                            {item.originalAuthor && ` / ${item.originalAuthor}`}
+                            {item.originalAuthor &&
+                              ` / ${item.originalAuthor}`}
                           </a>
                         </div>
                       )}

--- a/2026spring/frontend/src/app/derivative/articles/page.tsx
+++ b/2026spring/frontend/src/app/derivative/articles/page.tsx
@@ -37,12 +37,10 @@ function formatDate(dateStr?: string) {
 ========================= */
 function SkeletonCard() {
   return (
-    <div className="w-[760px] max-w-full rounded-xl bg-white p-4 shadow-sm">
+    <div className="w-full max-w-[760px] rounded-xl bg-white p-4 shadow-sm">
       <div className="flex gap-4 w-full">
-        {/* 画像 */}
-        <div className="w-44 h-28 bg-gray-200 rounded-lg animate-pulse" />
+        <div className="w-32 sm:w-44 h-20 sm:h-28 bg-gray-200 rounded-lg animate-pulse" />
 
-        {/* テキスト */}
         <div className="flex flex-col justify-between flex-1 min-w-0 gap-3">
           <div className="space-y-2">
             <div className="h-5 bg-gray-200 rounded w-3/4 animate-pulse" />
@@ -65,37 +63,71 @@ function SkeletonCard() {
 ========================= */
 export default function Page() {
   const [data, setData] = useState<Item[]>([]);
+  const [displayData, setDisplayData] = useState<Item[]>([]);
   const [loading, setLoading] = useState(true);
   const [ready, setReady] = useState(false);
+
+  const [searchText, setSearchText] = useState("");
 
   useEffect(() => {
     fetch("/api/derivative/articles")
       .then((res) => res.json())
       .then((res) => {
         setData(res);
+        setDisplayData(res);
         setLoading(false);
         setTimeout(() => setReady(true), 50);
       });
   }, []);
 
+  /* =========================
+     検索
+  ========================= */
+  useEffect(() => {
+    let filtered = [...data];
+
+    if (searchText.trim()) {
+      const q = searchText.toLowerCase();
+      filtered = filtered.filter((item) =>
+        (item.title + item.author).toLowerCase().includes(q)
+      );
+    }
+
+    setDisplayData(filtered);
+  }, [searchText, data]);
+
   return (
-    <div className="p-6 max-w-4xl mx-auto">
+    <div className="p-4 sm:p-6 flex flex-col items-center">
       {/* ヘッダー */}
-      <div className="text-center mb-10">
-        <h1 className="text-3xl md:text-4xl font-bold">
+      <div className="text-center mb-8 w-full max-w-[760px]">
+        <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold">
           note記事
         </h1>
 
-        <p className="text-sm text-gray-600 mt-2">
+        <p className="text-xs sm:text-sm text-gray-600 mt-2">
           「{CONFIG.event.name}」に関するnote記事を掲載しています。
         </p>
 
-        <div className="mt-4 border-b border-gray-200 max-w-xl mx-auto" />
+        {/* 下線統一 */}
+        <div className="mt-4 border-b border-gray-200 w-full" />
       </div>
+
+      {/* 検索 */}
+      {!loading && (
+        <div className="w-full max-w-[760px] mb-4 flex">
+          <input
+            type="text"
+            placeholder="検索"
+            value={searchText}
+            onChange={(e) => setSearchText(e.target.value)}
+            className="w-40 sm:w-56 border rounded px-2 py-1 text-sm"
+          />
+        </div>
+      )}
 
       {/* LOADING */}
       {loading && (
-        <div className="flex flex-col gap-6 items-center">
+        <div className="flex flex-col gap-6 items-center w-full">
           {Array.from({ length: 6 }).map((_, i) => (
             <SkeletonCard key={i} />
           ))}
@@ -103,20 +135,20 @@ export default function Page() {
       )}
 
       {/* EMPTY */}
-      {!loading && data.length === 0 && (
-        <div className="text-center py-20 text-gray-600">
+      {!loading && displayData.length === 0 && (
+        <div className="text-center py-20 text-gray-600 w-full max-w-[760px]">
           note記事はまだありません。
         </div>
       )}
 
       {/* CONTENT */}
-      {!loading && data.length > 0 && (
+      {!loading && displayData.length > 0 && (
         <div
-          className={`flex flex-col gap-6 items-center transition-opacity duration-300 ${
+          className={`flex flex-col gap-4 sm:gap-6 items-center w-full transition-opacity duration-300 ${
             ready ? "opacity-100" : "opacity-0"
           }`}
         >
-          {data.map((item, i) => {
+          {displayData.map((item, i) => {
             const img =
               item.eyecatchUrl?.trim()
                 ? item.eyecatchUrl
@@ -125,14 +157,14 @@ export default function Page() {
             return (
               <div
                 key={i}
-                className="group w-[760px] max-w-full rounded-xl bg-white p-4 shadow-sm hover:shadow-md transition"
+                className="group w-full max-w-[760px] rounded-xl bg-white p-3 sm:p-4 shadow-sm hover:shadow-md transition"
               >
-                <div className="flex gap-4 w-full">
+                <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 w-full">
                   {/* 画像 */}
                   <a
                     href={item.noteUrl}
                     target="_blank"
-                    className="w-44 h-28 flex-shrink-0 overflow-hidden rounded-lg"
+                    className="w-full sm:w-44 h-48 sm:h-28 flex-shrink-0 overflow-hidden rounded-lg"
                   >
                     <img
                       src={img}
@@ -142,16 +174,15 @@ export default function Page() {
 
                   {/* テキスト */}
                   <div className="flex flex-col justify-between flex-1 min-w-0">
-                    {/* 上段 */}
                     <div className="min-w-0">
                       {/* タイトル */}
                       <a href={item.noteUrl} target="_blank">
-                        <h2 className="text-lg md:text-xl font-bold leading-snug truncate group-hover:underline">
+                        <h2 className="text-base sm:text-lg md:text-xl font-bold leading-snug line-clamp-2 group-hover:underline">
                           {item.title}
                         </h2>
                       </a>
 
-                      {/* 投稿者（←位置変更） */}
+                      {/* 投稿者 */}
                       <div className="mt-2 flex items-center gap-2 min-w-0">
                         {item.userProfileImageUrl && (
                           <img

--- a/2026spring/frontend/src/app/derivative/articles/page.tsx
+++ b/2026spring/frontend/src/app/derivative/articles/page.tsx
@@ -46,6 +46,7 @@ function SkeletonCard() {
         <div className="flex flex-col justify-between flex-1 min-w-0 gap-3">
           <div className="space-y-2">
             <div className="h-5 bg-gray-200 rounded w-3/4 animate-pulse" />
+            <div className="h-4 bg-gray-200 rounded w-1/2 animate-pulse" />
             <div className="h-3 bg-gray-200 rounded w-24 animate-pulse" />
           </div>
 
@@ -141,36 +142,37 @@ export default function Page() {
 
                   {/* テキスト */}
                   <div className="flex flex-col justify-between flex-1 min-w-0">
-                    {/* タイトル＋日付 */}
+                    {/* 上段 */}
                     <div className="min-w-0">
+                      {/* タイトル */}
                       <a href={item.noteUrl} target="_blank">
                         <h2 className="text-lg md:text-xl font-bold leading-snug truncate group-hover:underline">
                           {item.title}
                         </h2>
                       </a>
 
+                      {/* 投稿者（←位置変更） */}
+                      <div className="mt-2 flex items-center gap-2 min-w-0">
+                        {item.userProfileImageUrl && (
+                          <img
+                            src={item.userProfileImageUrl}
+                            className="w-8 h-8 rounded-full object-cover"
+                          />
+                        )}
+
+                        <a
+                          href={item.userUrl}
+                          target="_blank"
+                          className="text-sm text-gray-700 font-medium truncate hover:underline"
+                        >
+                          {item.author}
+                        </a>
+                      </div>
+
                       {/* 投稿日 */}
                       <p className="text-xs text-gray-500 mt-1">
                         {formatDate(item.publishedAt)}
                       </p>
-                    </div>
-
-                    {/* 投稿者 */}
-                    <div className="mt-3 flex items-center gap-2 min-w-0">
-                      {item.userProfileImageUrl && (
-                        <img
-                          src={item.userProfileImageUrl}
-                          className="w-8 h-8 rounded-full object-cover"
-                        />
-                      )}
-
-                      <a
-                        href={item.userUrl}
-                        target="_blank"
-                        className="text-sm text-gray-700 font-medium truncate hover:underline"
-                      >
-                        {item.author}
-                      </a>
                     </div>
                   </div>
                 </div>

--- a/2026spring/frontend/src/app/derivative/coversongs/page.tsx
+++ b/2026spring/frontend/src/app/derivative/coversongs/page.tsx
@@ -19,20 +19,16 @@ type Item = {
 ========================= */
 function SkeletonCard() {
   return (
-    <div className="w-[760px] max-w-full rounded-xl bg-white p-4 shadow-sm">
+    <div className="w-full max-w-[760px] rounded-xl bg-white p-4 shadow-sm">
       <div className="flex gap-4 w-full">
-        {/* サムネ */}
-        <div className="w-44 h-28 bg-gray-200 rounded-lg animate-pulse" />
+        <div className="w-32 sm:w-44 h-20 sm:h-28 bg-gray-200 rounded-lg animate-pulse" />
 
-        {/* テキスト */}
         <div className="flex flex-col justify-between flex-1 min-w-0 gap-3">
-          {/* タイトル */}
           <div className="space-y-2">
             <div className="h-5 bg-gray-200 rounded w-3/4 animate-pulse" />
             <div className="h-4 bg-gray-200 rounded w-1/2 animate-pulse" />
           </div>
 
-          {/* メタ */}
           <div className="space-y-2">
             <div className="h-5 bg-gray-200 rounded w-24 animate-pulse" />
             <div className="h-10 bg-gray-200 rounded w-full animate-pulse" />
@@ -48,66 +44,100 @@ function SkeletonCard() {
 ========================= */
 export default function Page() {
   const [data, setData] = useState<Item[]>([]);
+  const [displayData, setDisplayData] = useState<Item[]>([]);
   const [loading, setLoading] = useState(true);
   const [ready, setReady] = useState(false);
+
+  const [searchText, setSearchText] = useState("");
 
   useEffect(() => {
     fetch("/api/derivative/coversongs")
       .then((res) => res.json())
       .then((res) => {
         setData(res);
+        setDisplayData(res);
         setLoading(false);
 
-        // フェードイン用
         setTimeout(() => setReady(true), 50);
       });
   }, []);
 
+  /* =========================
+     検索
+  ========================= */
+  useEffect(() => {
+    let filtered = [...data];
+
+    if (searchText.trim()) {
+      const q = searchText.toLowerCase();
+      filtered = filtered.filter((item) =>
+        (
+          item.title +
+          item.creator +
+          item.originalTitle +
+          item.originalAuthor
+        )
+          .toLowerCase()
+          .includes(q)
+      );
+    }
+
+    setDisplayData(filtered);
+  }, [searchText, data]);
+
   return (
-    <div className="p-6 max-w-4xl mx-auto">
+    <div className="p-4 sm:p-6 flex flex-col items-center">
       {/* ヘッダー */}
-      <div className="text-center mb-10">
-        <h1 className="text-3xl md:text-4xl font-bold">
+      <div className="text-center mb-8 w-full max-w-[760px]">
+        <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold">
           二次創作（歌ってみた）
         </h1>
 
-        <p className="text-sm text-gray-600 mt-2">
+        <p className="text-xs sm:text-sm text-gray-600 mt-2">
           「{CONFIG.event.name}」の歌ってみた作品を掲載しています。
         </p>
 
-        <div className="mt-4 border-b border-gray-200 max-w-xl mx-auto" />
+        {/* 下線を統一 */}
+        <div className="mt-4 border-b border-gray-200 w-full" />
       </div>
 
-      {/* =========================
-          LOADING (Skeleton)
-      ========================= */}
+      {/* 検索 */}
+      {!loading && (
+        <div className="w-full max-w-[760px] mb-4 flex">
+          <input
+            type="text"
+            placeholder="検索"
+            value={searchText}
+            onChange={(e) => setSearchText(e.target.value)}
+            className="w-40 sm:w-56 border rounded px-2 py-1 text-sm"
+          />
+        </div>
+      )}
+
+      {/* LOADING */}
       {loading && (
-        <div className="flex flex-col gap-6 items-center">
+        <div className="flex flex-col gap-6 items-center w-full">
           {Array.from({ length: 6 }).map((_, i) => (
             <SkeletonCard key={i} />
           ))}
         </div>
       )}
 
-      {/* =========================
-          EMPTY
-      ========================= */}
-      {!loading && data.length === 0 && (
-        <div className="text-center py-20 text-gray-600">
+      {/* EMPTY */}
+      {!loading && displayData.length === 0 && (
+        <div className="text-center py-20 text-gray-600 w-full max-w-[760px]">
           二次創作（歌ってみた）はまだありません。
         </div>
       )}
 
-      {/* =========================
-          CONTENT
-      ========================= */}
-      {!loading && data.length > 0 && (
+      {/* CONTENT */}
+      {!loading && displayData.length > 0 && (
         <div
-          className={`flex flex-col gap-6 items-center transition-opacity duration-300 ${
+          className={`flex flex-col gap-4 sm:gap-6 items-center w-full transition-opacity duration-300 ${
             ready ? "opacity-100" : "opacity-0"
           }`}
         >
-          {data.map((item, i) => {
+          {displayData.map((item, i) => {
             const img =
               item.imageUrl?.trim()
                 ? item.imageUrl
@@ -116,14 +146,15 @@ export default function Page() {
             return (
               <div
                 key={i}
-                className="group w-[760px] max-w-full rounded-xl bg-white p-4 shadow-sm hover:shadow-md transition"
+                className="group w-full max-w-[760px] rounded-xl bg-white p-3 sm:p-4 shadow-sm hover:shadow-md transition"
               >
-                <div className="flex gap-4 w-full">
+                {/* レスポンシブ */}
+                <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 w-full">
                   {/* サムネ */}
                   <a
                     href={item.workUrl}
                     target="_blank"
-                    className="w-44 h-28 flex-shrink-0 overflow-hidden rounded-lg"
+                    className="w-full sm:w-44 h-48 sm:h-28 flex-shrink-0 overflow-hidden rounded-lg"
                   >
                     <img
                       src={img}
@@ -133,10 +164,9 @@ export default function Page() {
 
                   {/* テキスト */}
                   <div className="flex flex-col justify-between flex-1 min-w-0">
-                    {/* タイトル */}
                     <div className="min-w-0">
                       <a href={item.workUrl} target="_blank">
-                        <h2 className="text-lg md:text-xl font-bold leading-snug truncate group-hover:underline">
+                        <h2 className="text-base sm:text-lg md:text-xl font-bold leading-snug line-clamp-2 group-hover:underline">
                           {item.title}
                         </h2>
                       </a>
@@ -146,9 +176,7 @@ export default function Page() {
                       </p>
                     </div>
 
-                    {/* メタ */}
                     <div className="mt-3 flex flex-col gap-2 w-full">
-                      {/* 投稿先 */}
                       {item.service && item.service !== "その他" && (
                         <div>
                           <span className="text-xs px-2 py-1 rounded-full bg-gray-100 text-gray-700 inline-block truncate max-w-full">
@@ -157,7 +185,6 @@ export default function Page() {
                         </div>
                       )}
 
-                      {/* Original */}
                       {item.originalTitle && (
                         <div className="bg-gray-50 px-3 py-2 rounded-lg text-xs text-gray-600 w-full min-w-0">
                           <a
@@ -166,7 +193,8 @@ export default function Page() {
                             className="block truncate underline hover:text-gray-800"
                           >
                             {item.originalTitle}
-                            {item.originalAuthor && ` / ${item.originalAuthor}`}
+                            {item.originalAuthor &&
+                              ` / ${item.originalAuthor}`}
                           </a>
                         </div>
                       )}

--- a/2026spring/frontend/src/app/derivative/illustrations/page.tsx
+++ b/2026spring/frontend/src/app/derivative/illustrations/page.tsx
@@ -19,19 +19,14 @@ type Item = {
 function SkeletonCard() {
   return (
     <div className="flex flex-col">
-      {/* 画像 */}
       <div className="aspect-square bg-gray-200 rounded-xl animate-pulse" />
 
-      {/* タイトル */}
       <div className="mt-2 space-y-2">
         <div className="h-4 bg-gray-200 rounded w-3/4 animate-pulse" />
         <div className="h-4 bg-gray-200 rounded w-1/2 animate-pulse" />
       </div>
 
-      {/* 作者 */}
       <div className="mt-2 h-4 bg-gray-200 rounded w-1/3 animate-pulse" />
-
-      {/* Original */}
       <div className="mt-2 h-10 bg-gray-200 rounded w-full animate-pulse" />
     </div>
   );
@@ -42,66 +37,99 @@ function SkeletonCard() {
 ========================= */
 export default function Page() {
   const [data, setData] = useState<Item[]>([]);
+  const [displayData, setDisplayData] = useState<Item[]>([]);
   const [loading, setLoading] = useState(true);
   const [ready, setReady] = useState(false);
+
+  const [searchText, setSearchText] = useState("");
 
   useEffect(() => {
     fetch("/api/derivative/illustrations")
       .then((res) => res.json())
       .then((res) => {
         setData(res);
+        setDisplayData(res);
         setLoading(false);
-
-        // フェードイン制御
         setTimeout(() => setReady(true), 50);
       });
   }, []);
 
+  /* =========================
+     検索
+  ========================= */
+  useEffect(() => {
+    let filtered = [...data];
+
+    if (searchText.trim()) {
+      const q = searchText.toLowerCase();
+      filtered = filtered.filter((item) =>
+        (
+          item.title +
+          item.creator +
+          item.originalTitle +
+          item.originalAuthor
+        )
+          .toLowerCase()
+          .includes(q)
+      );
+    }
+
+    setDisplayData(filtered);
+  }, [searchText, data]);
+
   return (
-    <div className="p-6">
-      {/* タイトル */}
-      <div className="text-center mb-10">
-        <h1 className="text-3xl md:text-4xl font-bold">
+    <div className="p-4 sm:p-6 flex flex-col items-center">
+      {/* ヘッダー */}
+      <div className="text-center mb-8 w-full max-w-6xl">
+        <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold">
           二次創作（イラスト）
         </h1>
 
-        <p className="text-sm text-gray-600 mt-2">
+        <p className="text-xs sm:text-sm text-gray-600 mt-2">
           「{CONFIG.event.name}」の二次創作イラストを掲載しています。
         </p>
 
-        <div className="mt-4 border-b border-gray-300 max-w-xl mx-auto" />
+        {/* 下線統一 */}
+        <div className="mt-4 border-b border-gray-200 w-full" />
       </div>
 
-      {/* =========================
-          LOADING
-      ========================= */}
+      {/* 検索 */}
+      {!loading && (
+        <div className="w-full max-w-6xl mb-4">
+          <input
+            type="text"
+            placeholder="検索"
+            value={searchText}
+            onChange={(e) => setSearchText(e.target.value)}
+            className="w-40 sm:w-56 border rounded px-2 py-1 text-sm"
+          />
+        </div>
+      )}
+
+      {/* LOADING */}
       {loading && (
-        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+        <div className="w-full max-w-6xl grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-6">
           {Array.from({ length: 12 }).map((_, i) => (
             <SkeletonCard key={i} />
           ))}
         </div>
       )}
 
-      {/* =========================
-          EMPTY
-      ========================= */}
-      {!loading && data.length === 0 && (
-        <div className="flex justify-center items-center min-h-[40vh] text-gray-600">
+      {/* EMPTY */}
+      {!loading && displayData.length === 0 && (
+        <div className="flex justify-center items-center min-h-[40vh] text-gray-600 w-full max-w-6xl">
           二次創作（イラスト）はまだありません。
         </div>
       )}
 
-      {/* =========================
-          CONTENT
-      ========================= */}
-      {!loading && data.length > 0 && (
+      {/* CONTENT */}
+      {!loading && displayData.length > 0 && (
         <div
-          className={`grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 transition-opacity duration-300 ${
+          className={`w-full max-w-6xl grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-6 transition-opacity duration-300 ${
             ready ? "opacity-100" : "opacity-0"
           }`}
         >
-          {data.map((item, i) => {
+          {displayData.map((item, i) => {
             const img =
               item.imageUrl?.trim()
                 ? item.imageUrl
@@ -121,13 +149,13 @@ export default function Page() {
 
                 {/* タイトル */}
                 <a href={item.workUrl} target="_blank">
-                  <h2 className="mt-2 font-bold text-sm md:text-base leading-snug line-clamp-2 min-h-[3rem] group-hover:underline">
+                  <h2 className="mt-2 font-bold text-sm sm:text-sm md:text-base leading-snug line-clamp-2 min-h-[3rem] group-hover:underline">
                     {item.title}
                   </h2>
                 </a>
 
                 {/* 作者 */}
-                <p className="text-sm text-gray-700 mt-1 font-medium line-clamp-1 min-h-[1.5rem]">
+                <p className="text-xs sm:text-sm text-gray-700 mt-1 font-medium line-clamp-1 min-h-[1.5rem]">
                   {item.creator}
                 </p>
 

--- a/2026spring/frontend/src/app/derivative/others/page.tsx
+++ b/2026spring/frontend/src/app/derivative/others/page.tsx
@@ -19,20 +19,16 @@ type Item = {
 ========================= */
 function SkeletonCard() {
   return (
-    <div className="w-[760px] max-w-full rounded-xl bg-white p-4 shadow-sm">
+    <div className="w-full max-w-[760px] rounded-xl bg-white p-4 shadow-sm">
       <div className="flex gap-4 w-full">
-        {/* サムネ */}
-        <div className="w-44 h-28 bg-gray-200 rounded-lg animate-pulse" />
+        <div className="w-32 sm:w-44 h-20 sm:h-28 bg-gray-200 rounded-lg animate-pulse" />
 
-        {/* テキスト */}
         <div className="flex flex-col justify-between flex-1 min-w-0 gap-3">
-          {/* タイトル */}
           <div className="space-y-2">
             <div className="h-5 bg-gray-200 rounded w-3/4 animate-pulse" />
             <div className="h-4 bg-gray-200 rounded w-1/2 animate-pulse" />
           </div>
 
-          {/* メタ */}
           <div className="space-y-2">
             <div className="h-5 bg-gray-200 rounded w-24 animate-pulse" />
             <div className="h-10 bg-gray-200 rounded w-full animate-pulse" />
@@ -48,66 +44,100 @@ function SkeletonCard() {
 ========================= */
 export default function Page() {
   const [data, setData] = useState<Item[]>([]);
+  const [displayData, setDisplayData] = useState<Item[]>([]);
   const [loading, setLoading] = useState(true);
   const [ready, setReady] = useState(false);
+
+  const [searchText, setSearchText] = useState("");
 
   useEffect(() => {
     fetch("/api/derivative/others")
       .then((res) => res.json())
       .then((res) => {
         setData(res);
+        setDisplayData(res);
         setLoading(false);
 
-        // フェードイン用
         setTimeout(() => setReady(true), 50);
       });
   }, []);
 
+  /* =========================
+     検索
+  ========================= */
+  useEffect(() => {
+    let filtered = [...data];
+
+    if (searchText.trim()) {
+      const q = searchText.toLowerCase();
+      filtered = filtered.filter((item) =>
+        (
+          item.title +
+          item.creator +
+          item.originalTitle +
+          item.originalAuthor
+        )
+          .toLowerCase()
+          .includes(q)
+      );
+    }
+
+    setDisplayData(filtered);
+  }, [searchText, data]);
+
   return (
-    <div className="p-6 max-w-4xl mx-auto">
+    <div className="p-4 sm:p-6 flex flex-col items-center">
       {/* ヘッダー */}
-      <div className="text-center mb-10">
-        <h1 className="text-3xl md:text-4xl font-bold">
+      <div className="text-center mb-8 w-full max-w-[760px]">
+        <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold">
           二次創作（その他）
         </h1>
 
-        <p className="text-sm text-gray-600 mt-2">
+        <p className="text-xs sm:text-sm text-gray-600 mt-2">
           「{CONFIG.event.name}」のその他の二次創作作品を掲載しています。
         </p>
 
-        <div className="mt-4 border-b border-gray-200 max-w-xl mx-auto" />
+        {/* 下線統一 */}
+        <div className="mt-4 border-b border-gray-200 w-full" />
       </div>
 
-      {/* =========================
-          LOADING (Skeleton)
-      ========================= */}
+      {/* 検索 */}
+      {!loading && (
+        <div className="w-full max-w-[760px] mb-4 flex">
+          <input
+            type="text"
+            placeholder="検索"
+            value={searchText}
+            onChange={(e) => setSearchText(e.target.value)}
+            className="w-40 sm:w-56 border rounded px-2 py-1 text-sm"
+          />
+        </div>
+      )}
+
+      {/* LOADING */}
       {loading && (
-        <div className="flex flex-col gap-6 items-center">
+        <div className="flex flex-col gap-6 items-center w-full">
           {Array.from({ length: 6 }).map((_, i) => (
             <SkeletonCard key={i} />
           ))}
         </div>
       )}
 
-      {/* =========================
-          EMPTY
-      ========================= */}
-      {!loading && data.length === 0 && (
-        <div className="text-center py-20 text-gray-600">
+      {/* EMPTY */}
+      {!loading && displayData.length === 0 && (
+        <div className="text-center py-20 text-gray-600 w-full max-w-[760px]">
           二次創作（その他）はまだありません。
         </div>
       )}
 
-      {/* =========================
-          CONTENT
-      ========================= */}
-      {!loading && data.length > 0 && (
+      {/* CONTENT */}
+      {!loading && displayData.length > 0 && (
         <div
-          className={`flex flex-col gap-6 items-center transition-opacity duration-300 ${
+          className={`flex flex-col gap-4 sm:gap-6 items-center w-full transition-opacity duration-300 ${
             ready ? "opacity-100" : "opacity-0"
           }`}
         >
-          {data.map((item, i) => {
+          {displayData.map((item, i) => {
             const img =
               item.imageUrl?.trim()
                 ? item.imageUrl
@@ -116,14 +146,14 @@ export default function Page() {
             return (
               <div
                 key={i}
-                className="group w-[760px] max-w-full rounded-xl bg-white p-4 shadow-sm hover:shadow-md transition"
+                className="group w-full max-w-[760px] rounded-xl bg-white p-3 sm:p-4 shadow-sm hover:shadow-md transition"
               >
-                <div className="flex gap-4 w-full">
+                <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 w-full">
                   {/* サムネ */}
                   <a
                     href={item.workUrl}
                     target="_blank"
-                    className="w-44 h-28 flex-shrink-0 overflow-hidden rounded-lg"
+                    className="w-full sm:w-44 h-48 sm:h-28 flex-shrink-0 overflow-hidden rounded-lg"
                   >
                     <img
                       src={img}
@@ -133,10 +163,9 @@ export default function Page() {
 
                   {/* テキスト */}
                   <div className="flex flex-col justify-between flex-1 min-w-0">
-                    {/* タイトル */}
                     <div className="min-w-0">
                       <a href={item.workUrl} target="_blank">
-                        <h2 className="text-lg md:text-xl font-bold leading-snug truncate group-hover:underline">
+                        <h2 className="text-base sm:text-lg md:text-xl font-bold leading-snug line-clamp-2 group-hover:underline">
                           {item.title}
                         </h2>
                       </a>
@@ -146,9 +175,7 @@ export default function Page() {
                       </p>
                     </div>
 
-                    {/* メタ */}
                     <div className="mt-3 flex flex-col gap-2 w-full">
-                      {/* 投稿先 */}
                       {item.service && item.service !== "その他" && (
                         <div>
                           <span className="text-xs px-2 py-1 rounded-full bg-gray-100 text-gray-700 inline-block truncate max-w-full">
@@ -157,7 +184,6 @@ export default function Page() {
                         </div>
                       )}
 
-                      {/* Original */}
                       {item.originalTitle && (
                         <div className="bg-gray-50 px-3 py-2 rounded-lg text-xs text-gray-600 w-full min-w-0">
                           <a
@@ -166,7 +192,8 @@ export default function Page() {
                             className="block truncate underline hover:text-gray-800"
                           >
                             {item.originalTitle}
-                            {item.originalAuthor && ` / ${item.originalAuthor}`}
+                            {item.originalAuthor &&
+                              ` / ${item.originalAuthor}`}
                           </a>
                         </div>
                       )}

--- a/2026spring/frontend/src/app/derivative/streams/page.tsx
+++ b/2026spring/frontend/src/app/derivative/streams/page.tsx
@@ -18,10 +18,8 @@ type Item = {
 function SkeletonTile() {
   return (
     <div className="w-full flex flex-col border border-gray-200 rounded-xl overflow-hidden">
-      {/* サムネ */}
       <div className="relative w-full aspect-video bg-gray-200 animate-pulse" />
 
-      {/* テキスト */}
       <div className="p-2 space-y-2">
         <div className="h-3 w-32 bg-gray-200 rounded animate-pulse" />
 
@@ -71,9 +69,7 @@ function parseDate(dt?: string) {
   };
 }
 
-/* =========================
-   ラベル
-========================= */
+/* ========================= */
 function getDayLabel(date?: Date) {
   if (!date) return null;
 
@@ -101,36 +97,70 @@ function isFuture(date?: Date) {
 ========================= */
 export default function Page() {
   const [data, setData] = useState<Item[]>([]);
+  const [displayData, setDisplayData] = useState<Item[]>([]);
   const [loading, setLoading] = useState(true);
+
+  const [searchText, setSearchText] = useState("");
 
   useEffect(() => {
     fetch("/api/derivative/streams")
       .then((res) => res.json())
       .then((res) => {
         setData(res);
+        setDisplayData(res);
         setLoading(false);
       });
   }, []);
 
+  /* =========================
+     検索
+  ========================= */
+  useEffect(() => {
+    let filtered = [...data];
+
+    if (searchText.trim()) {
+      const q = searchText.toLowerCase();
+      filtered = filtered.filter((item) =>
+        (item.title + item.creator).toLowerCase().includes(q)
+      );
+    }
+
+    setDisplayData(filtered);
+  }, [searchText, data]);
+
   return (
-    <div className="p-6 w-full max-w-6xl mx-auto">
+    <div className="p-4 sm:p-6 w-full flex flex-col items-center">
       {/* ヘッダー */}
-      <div className="text-center mb-10">
-        <h1 className="text-3xl md:text-4xl font-bold">
+      <div className="text-center mb-8 w-full max-w-6xl">
+        <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold">
           紹介配信
         </h1>
 
-        <p className="text-sm text-gray-600 mt-2">
+        <p className="text-xs sm:text-sm text-gray-600 mt-2">
           「{CONFIG.event.name}」の紹介配信を掲載しています。
         </p>
 
-        <div className="mt-4 border-b border-gray-200 max-w-xl mx-auto" />
+        {/* ← 下線を他ページと統一 */}
+        <div className="mt-4 border-b border-gray-200 w-full" />
       </div>
+
+      {/* 検索 */}
+      {!loading && (
+        <div className="w-full max-w-6xl mb-4">
+          <input
+            type="text"
+            placeholder="検索"
+            value={searchText}
+            onChange={(e) => setSearchText(e.target.value)}
+            className="w-40 sm:w-56 border rounded px-2 py-1 text-sm"
+          />
+        </div>
+      )}
 
       {/* LOADING */}
       {loading && (
-        <div className="w-full">
-          <div className="grid w-full grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+        <div className="w-full max-w-6xl">
+          <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-6">
             {Array.from({ length: 8 }).map((_, i) => (
               <SkeletonTile key={i} />
             ))}
@@ -139,77 +169,76 @@ export default function Page() {
       )}
 
       {/* EMPTY */}
-      {!loading && data.length === 0 && (
+      {!loading && displayData.length === 0 && (
         <div className="text-center py-20 text-gray-600">
           紹介配信はまだありません。
         </div>
       )}
 
       {/* GRID */}
-      {!loading && data.length > 0 && (
-        <div className="grid w-full grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-          {data.map((item, i) => {
-            const img =
-              item.imageUrl?.trim()
-                ? item.imageUrl
-                : CONFIG.images.defaultIllustration;
+      {!loading && displayData.length > 0 && (
+        <div className="w-full max-w-6xl">
+          <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-6">
+            {displayData.map((item, i) => {
+              const img =
+                item.imageUrl?.trim()
+                  ? item.imageUrl
+                  : CONFIG.images.defaultIllustration;
 
-            const parsed = parseDate(item.publishedAt);
-            const dayLabel = getDayLabel(parsed?.raw);
-            const future = isFuture(parsed?.raw);
+              const parsed = parseDate(item.publishedAt);
+              const dayLabel = getDayLabel(parsed?.raw);
+              const future = isFuture(parsed?.raw);
 
-            return (
-              <div
-                key={i}
-                className="flex flex-col group border border-gray-200 rounded-xl overflow-hidden transition hover:shadow-md"
-              >
-                <a
-                  href={item.workUrl}
-                  target="_blank"
-                  className="flex flex-col"
+              return (
+                <div
+                  key={i}
+                  className="flex flex-col group border border-gray-200 rounded-xl overflow-hidden transition hover:shadow-md"
                 >
-                  {/* サムネ */}
-                  <div className="relative aspect-video overflow-hidden">
-                    <img
-                      src={img}
-                      className="w-full h-full object-cover group-hover:scale-105 transition"
-                    />
+                  <a
+                    href={item.workUrl}
+                    target="_blank"
+                    className="flex flex-col"
+                  >
+                    <div className="relative aspect-video overflow-hidden">
+                      <img
+                        src={img}
+                        className="w-full h-full object-cover group-hover:scale-105 transition"
+                      />
 
-                    {/* 予定 */}
-                    {future && (
-                      <span className="absolute top-2 left-2 bg-black/80 text-white text-xs px-2 py-1 rounded">
-                        予定
-                      </span>
-                    )}
-                  </div>
-
-                  {/* テキスト */}
-                  <div className="flex flex-col mt-2 px-2 pb-2">
-                    <div className="text-xs text-gray-700 font-medium min-h-[1.2rem]">
-                      {parsed && (
-                        <>
-                          {dayLabel && (
-                            <span className="mr-1 text-blue-600 font-semibold">
-                              {dayLabel}
-                            </span>
-                          )}
-                          {parsed.label}
-                        </>
+                      {future && (
+                        <span className="absolute top-2 left-2 bg-black/80 text-white text-xs px-2 py-1 rounded">
+                          予定
+                        </span>
                       )}
                     </div>
 
-                    <h2 className="mt-1 text-sm font-bold leading-snug line-clamp-2 min-h-[2.8rem] group-hover:underline">
-                      {item.title}
-                    </h2>
+                    <div className="flex flex-col mt-2 px-2 pb-2">
+                      <div className="text-xs text-gray-700 font-medium min-h-[1.2rem]">
+                        {parsed && (
+                          <>
+                            {dayLabel && (
+                              <span className="mr-1 text-blue-600 font-semibold">
+                                {dayLabel}
+                              </span>
+                            )}
+                            {parsed.label}
+                          </>
+                        )}
+                      </div>
 
-                    <p className="text-xs text-gray-600 mt-1 truncate min-h-[1rem]">
-                      {item.creator}
-                    </p>
-                  </div>
-                </a>
-              </div>
-            );
-          })}
+                      <h2 className="mt-1 text-sm font-bold leading-snug line-clamp-2 min-h-[2.8rem] group-hover:underline">
+                        {item.title}
+                      </h2>
+
+                      <p className="text-xs text-gray-600 mt-1 truncate min-h-[1rem]">
+                        {item.creator}
+                      </p>
+                    </div>
+                  </a>
+                </div>
+              );
+            })}
+          </div>
         </div>
       )}
     </div>

--- a/2026spring/frontend/src/app/submissions/songs/extra/page.tsx
+++ b/2026spring/frontend/src/app/submissions/songs/extra/page.tsx
@@ -1,5 +1,291 @@
-import TBA from "@/components/TBA";
+"use client";
 
+import { useEffect, useState } from "react";
+import { CONFIG } from "@/config/config";
+
+type Item = {
+  title: string;
+  creator: string;
+  videoUrl: string;
+  thumbnailUrl: string;
+  publishedAt: string;
+  description: string;
+};
+
+/* =========================
+   日付整形
+========================= */
+function formatDate(dateStr?: string) {
+  if (!dateStr) return "";
+  const date = new Date(dateStr);
+  if (isNaN(date.getTime())) return "";
+
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+
+  return `${y}/${m}/${d}`;
+}
+
+/* =========================
+   概要欄整形
+========================= */
+function cleanDescription(text?: string) {
+  if (!text) return "";
+  return text
+    .replace(/<br\s*\/?>/gi, " ")
+    .replace(/\n/g, " ")
+    .trim();
+}
+
+/* =========================
+   日付パース
+========================= */
+function parseDate(dateStr?: string) {
+  if (!dateStr) return 0;
+  return new Date(dateStr).getTime();
+}
+
+/* =========================
+   シャッフル
+========================= */
+function shuffleArray<T>(array: T[]): T[] {
+  const arr = [...array];
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+/* =========================
+   Skeleton
+========================= */
+function SkeletonCard() {
+  return (
+    <div className="w-full max-w-[760px] rounded-xl bg-white p-4 shadow-sm">
+      <div className="flex gap-4">
+        <div className="w-40 h-24 bg-gray-200 rounded-lg animate-pulse" />
+        <div className="flex flex-col flex-1 gap-2">
+          <div className="h-5 bg-gray-200 rounded w-3/4 animate-pulse" />
+          <div className="h-4 bg-gray-200 rounded w-1/2 animate-pulse" />
+          <div className="h-3 bg-gray-200 rounded w-24 animate-pulse" />
+          <div className="h-4 bg-gray-200 rounded w-full animate-pulse" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* =========================
+   Page
+========================= */
 export default function Page() {
-  return <TBA title="楽曲一覧（エクストラ）" />;
+  const [data, setData] = useState<Item[]>([]);
+  const [displayData, setDisplayData] = useState<Item[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const [sortType, setSortType] = useState<"new" | "old">("new");
+  const [searchText, setSearchText] = useState("");
+  const [isRandom, setIsRandom] = useState(false);
+
+  /* 初期ロード */
+  useEffect(() => {
+    fetch("/api/submissions/songs/extra")
+      .then((res) => res.json())
+      .then((res) => {
+        setData(res);
+        setLoading(false);
+      });
+  }, []);
+
+  /* フィルタ + ソート */
+  useEffect(() => {
+    if (data.length === 0) return;
+
+    // ✅ ランダム中は上書きしない
+    if (isRandom) return;
+
+    let filtered = [...data];
+
+    if (searchText.trim()) {
+      const q = searchText.toLowerCase();
+      filtered = filtered.filter((item) =>
+        (item.title + item.creator + item.description)
+          .toLowerCase()
+          .includes(q)
+      );
+    }
+
+    if (sortType === "new") {
+      filtered.sort(
+        (a, b) => parseDate(b.publishedAt) - parseDate(a.publishedAt)
+      );
+    } else {
+      filtered.sort(
+        (a, b) => parseDate(a.publishedAt) - parseDate(b.publishedAt)
+      );
+    }
+
+    setDisplayData(filtered);
+  }, [data, sortType, searchText, isRandom]);
+
+  /* =========================
+     ランダム
+  ========================= */
+  const handleShuffle = () => {
+    let base = [...data];
+
+    // 検索中なら検索結果だけシャッフル
+    if (searchText.trim()) {
+      const q = searchText.toLowerCase();
+      base = base.filter((item) =>
+        (item.title + item.creator + item.description)
+          .toLowerCase()
+          .includes(q)
+      );
+    }
+
+    setDisplayData(shuffleArray(base));
+    setIsRandom(true);
+  };
+
+  /* =========================
+     ソート変更
+  ========================= */
+  const handleSortChange = (value: "new" | "old") => {
+    setSortType(value);
+    setIsRandom(false);
+  };
+
+  /* =========================
+     検索変更
+  ========================= */
+  const handleSearchChange = (value: string) => {
+    setSearchText(value);
+    setIsRandom(false);
+  };
+
+  return (
+    <div className="p-4 sm:p-6 flex flex-col items-center">
+      {/* ヘッダー */}
+      <div className="text-center mb-8 w-full max-w-[760px]">
+        <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold">
+          楽曲一覧 exステージ
+        </h1>
+
+        <p className="text-xs sm:text-sm text-gray-600 mt-2">
+          「{CONFIG.event.name}」のexステージ参加楽曲を掲載しています。
+        </p>
+
+        <div className="mt-4 border-b border-gray-200 w-full" />
+      </div>
+
+      {/* 検索 */}
+      {!loading && (
+        <div className="w-full max-w-[760px] mb-4 flex">
+          <input
+            type="text"
+            placeholder="検索"
+            value={searchText}
+            onChange={(e) => handleSearchChange(e.target.value)}
+            className="w-48 border rounded px-2 py-1 text-sm"
+          />
+        </div>
+      )}
+
+      {/* 操作バー */}
+      {!loading && data.length > 0 && (
+        <div className="w-full max-w-[760px] flex items-center justify-between mb-6">
+          <div className="flex items-center gap-2">
+            <select
+              value={isRandom ? "random" : sortType}
+              onChange={(e) => {
+                const val = e.target.value;
+                if (val === "random") return;
+                handleSortChange(val as "new" | "old");
+              }}
+              className="border rounded px-2 py-1 text-sm"
+            >
+              {isRandom && <option value="random">ランダム</option>}
+              <option value="new">新しい順</option>
+              <option value="old">古い順</option>
+            </select>
+
+            <button
+              onClick={handleShuffle}
+              className="px-2 py-1 text-sm rounded border active:scale-95 active:bg-gray-100 transition"
+            >
+              ランダムに並び替え
+            </button>
+          </div>
+
+          <div className="text-sm text-gray-600">
+            {displayData.length}件
+          </div>
+        </div>
+      )}
+
+      {/* Loading */}
+      {loading && (
+        <div className="flex flex-col gap-6 items-center w-full">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <SkeletonCard key={i} />
+          ))}
+        </div>
+      )}
+
+      {/* Empty */}
+      {!loading && displayData.length === 0 && (
+        <div className="text-center py-20 text-gray-600 w-full max-w-[760px]">
+          該当する動画がありません。
+        </div>
+      )}
+
+      {/* Content */}
+      {!loading && displayData.length > 0 && (
+        <div className="flex flex-col gap-6 items-center w-full">
+          {displayData.map((item, i) => (
+            <div
+              key={i}
+              className="group w-full max-w-[760px] rounded-xl bg-white p-4 shadow-sm hover:shadow-md transition"
+            >
+              <div className="flex gap-4">
+                <a
+                  href={item.videoUrl}
+                  target="_blank"
+                  className="w-40 h-24 flex-shrink-0 overflow-hidden rounded-lg"
+                >
+                  <img
+                    src={item.thumbnailUrl}
+                    className="w-full h-full object-cover group-hover:scale-105 transition"
+                  />
+                </a>
+
+                <div className="flex flex-col flex-1 min-w-0">
+                  <a href={item.videoUrl} target="_blank">
+                    <h2 className="text-base sm:text-lg font-bold leading-snug line-clamp-2 group-hover:underline">
+                      {item.title}
+                    </h2>
+                  </a>
+
+                  <p className="text-sm text-gray-700 font-medium mt-1 truncate">
+                    {item.creator}
+                  </p>
+
+                  <p className="text-xs text-gray-500 mt-1">
+                    {formatDate(item.publishedAt)}
+                  </p>
+
+                  <p className="text-sm text-gray-600 mt-2 line-clamp-2">
+                    {cleanDescription(item.description)}
+                  </p>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
 }

--- a/2026spring/frontend/src/app/submissions/songs/opening/page.tsx
+++ b/2026spring/frontend/src/app/submissions/songs/opening/page.tsx
@@ -1,0 +1,289 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { CONFIG } from "@/config/config";
+
+type Item = {
+  title: string;
+  creator: string;
+  videoUrl: string;
+  thumbnailUrl: string;
+  publishedAt: string;
+  description: string;
+};
+
+/* =========================
+   日付整形
+========================= */
+function formatDate(dateStr?: string) {
+  if (!dateStr) return "";
+
+  const date = new Date(dateStr);
+  if (isNaN(date.getTime())) return "";
+
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+
+  return `${y}/${m}/${d}`;
+}
+
+/* =========================
+   概要欄整形
+========================= */
+function cleanDescription(text?: string) {
+  if (!text) return "";
+
+  return text
+    .replace(/<br\s*\/?>/gi, " ")
+    .replace(/\n/g, " ")
+    .trim();
+}
+
+/* =========================
+   日付パース
+========================= */
+function parseDate(dateStr?: string) {
+  if (!dateStr) return 0;
+  return new Date(dateStr).getTime();
+}
+
+/* =========================
+   シャッフル
+========================= */
+function shuffleArray<T>(array: T[]): T[] {
+  const arr = [...array];
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+/* =========================
+   Skeleton
+========================= */
+function SkeletonCard() {
+  return (
+    <div className="w-[760px] max-w-full rounded-xl bg-white p-4 shadow-sm">
+      <div className="flex gap-4">
+        <div className="w-44 h-28 bg-gray-200 rounded-lg animate-pulse" />
+
+        <div className="flex flex-col flex-1 gap-2">
+          <div className="h-5 bg-gray-200 rounded w-3/4 animate-pulse" />
+          <div className="h-4 bg-gray-200 rounded w-1/2 animate-pulse" />
+          <div className="h-3 bg-gray-200 rounded w-24 animate-pulse" />
+          <div className="h-4 bg-gray-200 rounded w-full animate-pulse" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* =========================
+   Page
+========================= */
+export default function Page() {
+  const [data, setData] = useState<Item[]>([]);
+  const [displayData, setDisplayData] = useState<Item[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const [sortType, setSortType] = useState<"new" | "old">("new");
+  const [isShuffled, setIsShuffled] = useState(false);
+
+  /* =========================
+     初期読み込み
+  ========================= */
+  useEffect(() => {
+    fetch("/api/submissions/songs/opening")
+      .then((res) => res.json())
+      .then((res) => {
+        setData(res);
+        setLoading(false);
+      });
+  }, []);
+
+  /* =========================
+     localStorage復元
+  ========================= */
+  useEffect(() => {
+    const savedSort = localStorage.getItem("video_sort");
+    const savedShuffle = localStorage.getItem("video_shuffle");
+
+    if (savedSort === "new" || savedSort === "old") {
+      setSortType(savedSort);
+    }
+
+    if (savedShuffle === "true") {
+      setIsShuffled(true);
+    }
+  }, []);
+
+  /* =========================
+     並び替え処理
+  ========================= */
+  useEffect(() => {
+    if (data.length === 0) return;
+
+    let result = [...data];
+
+    if (isShuffled) {
+      const saved = localStorage.getItem("video_order");
+
+      if (saved) {
+        const order: string[] = JSON.parse(saved);
+        result.sort(
+          (a, b) =>
+            order.indexOf(a.videoUrl) - order.indexOf(b.videoUrl)
+        );
+      } else {
+        result = shuffleArray(data);
+      }
+    } else {
+      if (sortType === "new") {
+        result.sort(
+          (a, b) => parseDate(b.publishedAt) - parseDate(a.publishedAt)
+        );
+      } else {
+        result.sort(
+          (a, b) => parseDate(a.publishedAt) - parseDate(b.publishedAt)
+        );
+      }
+    }
+
+    setDisplayData(result);
+  }, [data, sortType, isShuffled]);
+
+  /* =========================
+     ランダム
+  ========================= */
+  const handleShuffle = () => {
+    const shuffled = shuffleArray(data);
+
+    setDisplayData(shuffled);
+    setIsShuffled(true);
+
+    localStorage.setItem("video_shuffle", "true");
+    localStorage.setItem(
+      "video_order",
+      JSON.stringify(shuffled.map((v) => v.videoUrl))
+    );
+  };
+
+  /* =========================
+     ソート変更
+  ========================= */
+  const handleSortChange = (value: "new" | "old") => {
+    setSortType(value);
+    setIsShuffled(false);
+
+    localStorage.setItem("video_sort", value);
+    localStorage.setItem("video_shuffle", "false");
+    localStorage.removeItem("video_order");
+  };
+
+  return (
+    <div className="p-6 max-w-4xl mx-auto">
+      {/* ヘッダー */}
+      <div className="text-center mb-10">
+        <h1 className="text-3xl md:text-4xl font-bold">
+          楽曲一覧 オープニング
+        </h1>
+
+        <p className="text-sm text-gray-600 mt-2">
+          「{CONFIG.event.name}」のオープニングステージ参加楽曲を掲載しています。
+        </p>
+
+        <div className="mt-4 border-b border-gray-200 max-w-xl mx-auto" />
+      </div>
+
+      {/* 操作バー */}
+      {!loading && data.length > 0 && (
+        <div className="flex items-center gap-3 mb-6">
+          <select
+            value={isShuffled ? "random" : sortType}
+            onChange={(e) => {
+              const value = e.target.value;
+
+              if (value === "random") return;
+
+              handleSortChange(value as "new" | "old");
+            }}
+            className="border rounded px-3 py-1 text-sm"
+          >
+            {isShuffled && <option value="random">ランダム</option>}
+            <option value="new">新しい順</option>
+            <option value="old">古い順</option>
+          </select>
+
+          <button
+            onClick={handleShuffle}
+            className="px-3 py-1 text-sm rounded border bg-white hover:bg-gray-100 active:scale-95 transition"
+          >
+            ランダムに並び替え
+          </button>
+        </div>
+      )}
+
+      {/* Loading */}
+      {loading && (
+        <div className="flex flex-col gap-6 items-center">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <SkeletonCard key={i} />
+          ))}
+        </div>
+      )}
+
+      {/* Content */}
+      {!loading && displayData.length > 0 && (
+        <div className="flex flex-col gap-6 items-center">
+          {displayData.map((item, i) => (
+            <div
+              key={i}
+              className="group w-[760px] max-w-full rounded-xl bg-white p-4 shadow-sm hover:shadow-md transition"
+            >
+              <div className="flex gap-4">
+                {/* サムネ */}
+                <a
+                  href={item.videoUrl}
+                  target="_blank"
+                  className="w-44 h-28 flex-shrink-0 overflow-hidden rounded-lg"
+                >
+                  <img
+                    src={item.thumbnailUrl}
+                    className="w-full h-full object-cover group-hover:scale-105 transition"
+                  />
+                </a>
+
+                {/* テキスト */}
+                <div className="flex flex-col flex-1 min-w-0">
+                  {/* タイトル */}
+                  <a href={item.videoUrl} target="_blank">
+                    <h2 className="text-lg font-bold truncate group-hover:underline">
+                      {item.title}
+                    </h2>
+                  </a>
+
+                  {/* 投稿者 */}
+                  <p className="text-sm text-gray-700 mt-1 truncate">
+                    {item.creator}
+                  </p>
+
+                  {/* 投稿日 */}
+                  <p className="text-xs text-gray-500 mt-1">
+                    {formatDate(item.publishedAt)}
+                  </p>
+
+                  {/* 概要 */}
+                  <p className="text-sm text-gray-600 mt-2 line-clamp-2">
+                    {cleanDescription(item.description)}
+                  </p>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/2026spring/frontend/src/app/submissions/songs/opening/page.tsx
+++ b/2026spring/frontend/src/app/submissions/songs/opening/page.tsx
@@ -17,7 +17,6 @@ type Item = {
 ========================= */
 function formatDate(dateStr?: string) {
   if (!dateStr) return "";
-
   const date = new Date(dateStr);
   if (isNaN(date.getTime())) return "";
 
@@ -33,7 +32,6 @@ function formatDate(dateStr?: string) {
 ========================= */
 function cleanDescription(text?: string) {
   if (!text) return "";
-
   return text
     .replace(/<br\s*\/?>/gi, " ")
     .replace(/\n/g, " ")
@@ -65,9 +63,9 @@ function shuffleArray<T>(array: T[]): T[] {
 ========================= */
 function SkeletonCard() {
   return (
-    <div className="w-[760px] max-w-full rounded-xl bg-white p-4 shadow-sm">
+    <div className="w-full max-w-[760px] rounded-xl bg-white p-4 shadow-sm">
       <div className="flex gap-4">
-        <div className="w-44 h-28 bg-gray-200 rounded-lg animate-pulse" />
+        <div className="w-40 h-24 bg-gray-200 rounded-lg animate-pulse" />
         <div className="flex flex-col flex-1 gap-2">
           <div className="h-5 bg-gray-200 rounded w-3/4 animate-pulse" />
           <div className="h-4 bg-gray-200 rounded w-1/2 animate-pulse" />
@@ -87,16 +85,11 @@ export default function Page() {
   const [displayData, setDisplayData] = useState<Item[]>([]);
   const [loading, setLoading] = useState(true);
 
-  // 初期値は固定（←これ重要）
   const [sortType, setSortType] = useState<"new" | "old">("new");
-  const [isShuffled, setIsShuffled] = useState(false);
+  const [searchText, setSearchText] = useState("");
+  const [isRandom, setIsRandom] = useState(false);
 
-  // ボタンアニメ用
-  const [shuffleActive, setShuffleActive] = useState(false);
-
-  /* =========================
-     データ取得
-  ========================= */
+  /* 初期ロード */
   useEffect(() => {
     fetch("/api/submissions/songs/opening")
       .then((res) => res.json())
@@ -106,143 +99,162 @@ export default function Page() {
       });
   }, []);
 
-  /* =========================
-     localStorage 復元（クライアントのみ）
-  ========================= */
-  useEffect(() => {
-    const savedSort = localStorage.getItem("video_sort");
-    const savedShuffle = localStorage.getItem("video_shuffle");
-    const savedData = localStorage.getItem("video_order");
-
-    if (savedSort === "new" || savedSort === "old") {
-      setSortType(savedSort);
-    }
-
-    if (savedShuffle === "true" && savedData) {
-      setDisplayData(JSON.parse(savedData));
-      setIsShuffled(true);
-    }
-  }, []);
-
-  /* =========================
-     ソート処理
-  ========================= */
+  /* フィルタ + ソート */
   useEffect(() => {
     if (data.length === 0) return;
-    if (isShuffled) return;
 
-    let sorted = [...data];
+    // ✅ ランダム中は上書きしない
+    if (isRandom) return;
+
+    let filtered = [...data];
+
+    if (searchText.trim()) {
+      const q = searchText.toLowerCase();
+      filtered = filtered.filter((item) =>
+        (item.title + item.creator + item.description)
+          .toLowerCase()
+          .includes(q)
+      );
+    }
 
     if (sortType === "new") {
-      sorted.sort(
+      filtered.sort(
         (a, b) => parseDate(b.publishedAt) - parseDate(a.publishedAt)
       );
     } else {
-      sorted.sort(
+      filtered.sort(
         (a, b) => parseDate(a.publishedAt) - parseDate(b.publishedAt)
       );
     }
 
-    setDisplayData(sorted);
-
-    localStorage.setItem("video_sort", sortType);
-    localStorage.setItem("video_shuffle", "false");
-  }, [data, sortType, isShuffled]);
+    setDisplayData(filtered);
+  }, [data, sortType, searchText, isRandom]);
 
   /* =========================
      ランダム
   ========================= */
   const handleShuffle = () => {
-    const shuffled = shuffleArray(data);
+    let base = [...data];
 
-    setDisplayData(shuffled);
-    setIsShuffled(true);
+    // 検索中なら検索結果だけシャッフル
+    if (searchText.trim()) {
+      const q = searchText.toLowerCase();
+      base = base.filter((item) =>
+        (item.title + item.creator + item.description)
+          .toLowerCase()
+          .includes(q)
+      );
+    }
 
-    localStorage.setItem("video_shuffle", "true");
-    localStorage.setItem("video_order", JSON.stringify(shuffled));
+    setDisplayData(shuffleArray(base));
+    setIsRandom(true);
+  };
 
-    // 押した感（軽いスケール）
-    setShuffleActive(true);
-    setTimeout(() => setShuffleActive(false), 150);
+  /* =========================
+     ソート変更
+  ========================= */
+  const handleSortChange = (value: "new" | "old") => {
+    setSortType(value);
+    setIsRandom(false);
+  };
+
+  /* =========================
+     検索変更
+  ========================= */
+  const handleSearchChange = (value: string) => {
+    setSearchText(value);
+    setIsRandom(false);
   };
 
   return (
-    <div className="p-6 max-w-4xl mx-auto">
+    <div className="p-4 sm:p-6 flex flex-col items-center">
       {/* ヘッダー */}
-      <div className="text-center mb-10">
-        <h1 className="text-3xl md:text-4xl font-bold">
-          楽曲一覧 オープニング
+      <div className="text-center mb-8 w-full max-w-[760px]">
+        <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold">
+          楽曲一覧 opステージ
         </h1>
 
-        <p className="text-sm text-gray-600 mt-2">
-          「{CONFIG.event.name}」のオープニングステージ参加楽曲を掲載しています。
+        <p className="text-xs sm:text-sm text-gray-600 mt-2">
+          「{CONFIG.event.name}」のopステージ参加楽曲を掲載しています。
         </p>
 
-        <div className="mt-4 border-b border-gray-200 max-w-xl mx-auto" />
+        <div className="mt-4 border-b border-gray-200 w-full" />
       </div>
+
+      {/* 検索 */}
+      {!loading && (
+        <div className="w-full max-w-[760px] mb-4 flex">
+          <input
+            type="text"
+            placeholder="検索"
+            value={searchText}
+            onChange={(e) => handleSearchChange(e.target.value)}
+            className="w-48 border rounded px-2 py-1 text-sm"
+          />
+        </div>
+      )}
 
       {/* 操作バー */}
       {!loading && data.length > 0 && (
-        <div className="flex items-center justify-between mb-6">
-          {/* 左側（操作） */}
-          <div className="flex items-center gap-3">
+        <div className="w-full max-w-[760px] flex items-center justify-between mb-6">
+          <div className="flex items-center gap-2">
             <select
-              value={isShuffled ? "random" : sortType}
+              value={isRandom ? "random" : sortType}
               onChange={(e) => {
-                const value = e.target.value;
-
-                if (value === "random") return;
-
-                setSortType(value as "new" | "old");
-                setIsShuffled(false);
+                const val = e.target.value;
+                if (val === "random") return;
+                handleSortChange(val as "new" | "old");
               }}
-              className="border rounded px-3 py-1 text-sm"
+              className="border rounded px-2 py-1 text-sm"
             >
+              {isRandom && <option value="random">ランダム</option>}
               <option value="new">新しい順</option>
               <option value="old">古い順</option>
-              <option value="random">ランダム</option>
             </select>
 
             <button
               onClick={handleShuffle}
-              className={`px-3 py-1 text-sm rounded border transition-transform duration-150 ${
-                shuffleActive ? "scale-95 bg-gray-200" : "bg-white"
-              }`}
+              className="px-2 py-1 text-sm rounded border active:scale-95 active:bg-gray-100 transition"
             >
               ランダムに並び替え
             </button>
           </div>
 
-          {/* 右側（件数） */}
           <div className="text-sm text-gray-600">
-            全 {displayData.length} 件
+            {displayData.length}件
           </div>
         </div>
       )}
 
       {/* Loading */}
       {loading && (
-        <div className="flex flex-col gap-6 items-center">
+        <div className="flex flex-col gap-6 items-center w-full">
           {Array.from({ length: 6 }).map((_, i) => (
             <SkeletonCard key={i} />
           ))}
         </div>
       )}
 
+      {/* Empty */}
+      {!loading && displayData.length === 0 && (
+        <div className="text-center py-20 text-gray-600 w-full max-w-[760px]">
+          該当する動画がありません。
+        </div>
+      )}
+
       {/* Content */}
       {!loading && displayData.length > 0 && (
-        <div className="flex flex-col gap-6 items-center">
+        <div className="flex flex-col gap-6 items-center w-full">
           {displayData.map((item, i) => (
             <div
               key={i}
-              className="group w-[760px] max-w-full rounded-xl bg-white p-4 shadow-sm hover:shadow-md transition"
+              className="group w-full max-w-[760px] rounded-xl bg-white p-4 shadow-sm hover:shadow-md transition"
             >
               <div className="flex gap-4">
-                {/* サムネ */}
                 <a
                   href={item.videoUrl}
                   target="_blank"
-                  className="w-44 h-28 flex-shrink-0 overflow-hidden rounded-lg"
+                  className="w-40 h-24 flex-shrink-0 overflow-hidden rounded-lg"
                 >
                   <img
                     src={item.thumbnailUrl}
@@ -250,15 +262,14 @@ export default function Page() {
                   />
                 </a>
 
-                {/* テキスト */}
                 <div className="flex flex-col flex-1 min-w-0">
                   <a href={item.videoUrl} target="_blank">
-                    <h2 className="text-lg font-bold truncate group-hover:underline">
+                    <h2 className="text-base sm:text-lg font-bold leading-snug line-clamp-2 group-hover:underline">
                       {item.title}
                     </h2>
                   </a>
 
-                  <p className="text-sm text-gray-800 font-medium mt-1 truncate">
+                  <p className="text-sm text-gray-700 font-medium mt-1 truncate">
                     {item.creator}
                   </p>
 

--- a/2026spring/frontend/src/app/submissions/songs/opening/page.tsx
+++ b/2026spring/frontend/src/app/submissions/songs/opening/page.tsx
@@ -68,7 +68,6 @@ function SkeletonCard() {
     <div className="w-[760px] max-w-full rounded-xl bg-white p-4 shadow-sm">
       <div className="flex gap-4">
         <div className="w-44 h-28 bg-gray-200 rounded-lg animate-pulse" />
-
         <div className="flex flex-col flex-1 gap-2">
           <div className="h-5 bg-gray-200 rounded w-3/4 animate-pulse" />
           <div className="h-4 bg-gray-200 rounded w-1/2 animate-pulse" />
@@ -88,11 +87,15 @@ export default function Page() {
   const [displayData, setDisplayData] = useState<Item[]>([]);
   const [loading, setLoading] = useState(true);
 
+  // 初期値は固定（←これ重要）
   const [sortType, setSortType] = useState<"new" | "old">("new");
   const [isShuffled, setIsShuffled] = useState(false);
 
+  // ボタンアニメ用
+  const [shuffleActive, setShuffleActive] = useState(false);
+
   /* =========================
-     初期読み込み
+     データ取得
   ========================= */
   useEffect(() => {
     fetch("/api/submissions/songs/opening")
@@ -104,54 +107,46 @@ export default function Page() {
   }, []);
 
   /* =========================
-     localStorage復元
+     localStorage 復元（クライアントのみ）
   ========================= */
   useEffect(() => {
     const savedSort = localStorage.getItem("video_sort");
     const savedShuffle = localStorage.getItem("video_shuffle");
+    const savedData = localStorage.getItem("video_order");
 
     if (savedSort === "new" || savedSort === "old") {
       setSortType(savedSort);
     }
 
-    if (savedShuffle === "true") {
+    if (savedShuffle === "true" && savedData) {
+      setDisplayData(JSON.parse(savedData));
       setIsShuffled(true);
     }
   }, []);
 
   /* =========================
-     並び替え処理
+     ソート処理
   ========================= */
   useEffect(() => {
     if (data.length === 0) return;
+    if (isShuffled) return;
 
-    let result = [...data];
+    let sorted = [...data];
 
-    if (isShuffled) {
-      const saved = localStorage.getItem("video_order");
-
-      if (saved) {
-        const order: string[] = JSON.parse(saved);
-        result.sort(
-          (a, b) =>
-            order.indexOf(a.videoUrl) - order.indexOf(b.videoUrl)
-        );
-      } else {
-        result = shuffleArray(data);
-      }
+    if (sortType === "new") {
+      sorted.sort(
+        (a, b) => parseDate(b.publishedAt) - parseDate(a.publishedAt)
+      );
     } else {
-      if (sortType === "new") {
-        result.sort(
-          (a, b) => parseDate(b.publishedAt) - parseDate(a.publishedAt)
-        );
-      } else {
-        result.sort(
-          (a, b) => parseDate(a.publishedAt) - parseDate(b.publishedAt)
-        );
-      }
+      sorted.sort(
+        (a, b) => parseDate(a.publishedAt) - parseDate(b.publishedAt)
+      );
     }
 
-    setDisplayData(result);
+    setDisplayData(sorted);
+
+    localStorage.setItem("video_sort", sortType);
+    localStorage.setItem("video_shuffle", "false");
   }, [data, sortType, isShuffled]);
 
   /* =========================
@@ -164,22 +159,11 @@ export default function Page() {
     setIsShuffled(true);
 
     localStorage.setItem("video_shuffle", "true");
-    localStorage.setItem(
-      "video_order",
-      JSON.stringify(shuffled.map((v) => v.videoUrl))
-    );
-  };
+    localStorage.setItem("video_order", JSON.stringify(shuffled));
 
-  /* =========================
-     ソート変更
-  ========================= */
-  const handleSortChange = (value: "new" | "old") => {
-    setSortType(value);
-    setIsShuffled(false);
-
-    localStorage.setItem("video_sort", value);
-    localStorage.setItem("video_shuffle", "false");
-    localStorage.removeItem("video_order");
+    // 押した感（軽いスケール）
+    setShuffleActive(true);
+    setTimeout(() => setShuffleActive(false), 150);
   };
 
   return (
@@ -199,29 +183,40 @@ export default function Page() {
 
       {/* 操作バー */}
       {!loading && data.length > 0 && (
-        <div className="flex items-center gap-3 mb-6">
-          <select
-            value={isShuffled ? "random" : sortType}
-            onChange={(e) => {
-              const value = e.target.value;
+        <div className="flex items-center justify-between mb-6">
+          {/* 左側（操作） */}
+          <div className="flex items-center gap-3">
+            <select
+              value={isShuffled ? "random" : sortType}
+              onChange={(e) => {
+                const value = e.target.value;
 
-              if (value === "random") return;
+                if (value === "random") return;
 
-              handleSortChange(value as "new" | "old");
-            }}
-            className="border rounded px-3 py-1 text-sm"
-          >
-            {isShuffled && <option value="random">ランダム</option>}
-            <option value="new">新しい順</option>
-            <option value="old">古い順</option>
-          </select>
+                setSortType(value as "new" | "old");
+                setIsShuffled(false);
+              }}
+              className="border rounded px-3 py-1 text-sm"
+            >
+              <option value="new">新しい順</option>
+              <option value="old">古い順</option>
+              <option value="random">ランダム</option>
+            </select>
 
-          <button
-            onClick={handleShuffle}
-            className="px-3 py-1 text-sm rounded border bg-white hover:bg-gray-100 active:scale-95 transition"
-          >
-            ランダムに並び替え
-          </button>
+            <button
+              onClick={handleShuffle}
+              className={`px-3 py-1 text-sm rounded border transition-transform duration-150 ${
+                shuffleActive ? "scale-95 bg-gray-200" : "bg-white"
+              }`}
+            >
+              ランダムに並び替え
+            </button>
+          </div>
+
+          {/* 右側（件数） */}
+          <div className="text-sm text-gray-600">
+            全 {displayData.length} 件
+          </div>
         </div>
       )}
 
@@ -257,24 +252,20 @@ export default function Page() {
 
                 {/* テキスト */}
                 <div className="flex flex-col flex-1 min-w-0">
-                  {/* タイトル */}
                   <a href={item.videoUrl} target="_blank">
                     <h2 className="text-lg font-bold truncate group-hover:underline">
                       {item.title}
                     </h2>
                   </a>
 
-                  {/* 投稿者 */}
-                  <p className="text-sm text-gray-700 mt-1 truncate">
+                  <p className="text-sm text-gray-800 font-medium mt-1 truncate">
                     {item.creator}
                   </p>
 
-                  {/* 投稿日 */}
                   <p className="text-xs text-gray-500 mt-1">
                     {formatDate(item.publishedAt)}
                   </p>
 
-                  {/* 概要 */}
                   <p className="text-sm text-gray-600 mt-2 line-clamp-2">
                     {cleanDescription(item.description)}
                   </p>

--- a/2026spring/frontend/src/app/submissions/songs/rookie/page.tsx
+++ b/2026spring/frontend/src/app/submissions/songs/rookie/page.tsx
@@ -1,33 +1,291 @@
-import VideoCard from "@/components/video/VideoCard"
+"use client";
 
-async function getVideos() {
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL
+import { useEffect, useState } from "react";
+import { CONFIG } from "@/config/config";
 
-  const res = await fetch("https://hontono-rookie-git-473f67-hontonorookiewebdesign-8612s-projects.vercel.app/api/videos",
-  {
-    cache: "no-store"
-  })
+type Item = {
+  title: string;
+  creator: string;
+  videoUrl: string;
+  thumbnailUrl: string;
+  publishedAt: string;
+  description: string;
+};
 
-  const data = await res.json()
-  return Array.isArray(data) ? data : []
+/* =========================
+   日付整形
+========================= */
+function formatDate(dateStr?: string) {
+  if (!dateStr) return "";
+  const date = new Date(dateStr);
+  if (isNaN(date.getTime())) return "";
+
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+
+  return `${y}/${m}/${d}`;
 }
 
-export default async function Page() {
-  const videos = await getVideos()
+/* =========================
+   概要欄整形
+========================= */
+function cleanDescription(text?: string) {
+  if (!text) return "";
+  return text
+    .replace(/<br\s*\/?>/gi, " ")
+    .replace(/\n/g, " ")
+    .trim();
+}
+
+/* =========================
+   日付パース
+========================= */
+function parseDate(dateStr?: string) {
+  if (!dateStr) return 0;
+  return new Date(dateStr).getTime();
+}
+
+/* =========================
+   シャッフル
+========================= */
+function shuffleArray<T>(array: T[]): T[] {
+  const arr = [...array];
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+/* =========================
+   Skeleton
+========================= */
+function SkeletonCard() {
+  return (
+    <div className="w-full max-w-[760px] rounded-xl bg-white p-4 shadow-sm">
+      <div className="flex gap-4">
+        <div className="w-40 h-24 bg-gray-200 rounded-lg animate-pulse" />
+        <div className="flex flex-col flex-1 gap-2">
+          <div className="h-5 bg-gray-200 rounded w-3/4 animate-pulse" />
+          <div className="h-4 bg-gray-200 rounded w-1/2 animate-pulse" />
+          <div className="h-3 bg-gray-200 rounded w-24 animate-pulse" />
+          <div className="h-4 bg-gray-200 rounded w-full animate-pulse" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* =========================
+   Page
+========================= */
+export default function Page() {
+  const [data, setData] = useState<Item[]>([]);
+  const [displayData, setDisplayData] = useState<Item[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const [sortType, setSortType] = useState<"new" | "old">("new");
+  const [searchText, setSearchText] = useState("");
+  const [isRandom, setIsRandom] = useState(false);
+
+  /* 初期ロード */
+  useEffect(() => {
+    fetch("/api/submissions/songs/rookie")
+      .then((res) => res.json())
+      .then((res) => {
+        setData(res);
+        setLoading(false);
+      });
+  }, []);
+
+  /* フィルタ + ソート */
+  useEffect(() => {
+    if (data.length === 0) return;
+
+    // ✅ ランダム中は上書きしない
+    if (isRandom) return;
+
+    let filtered = [...data];
+
+    if (searchText.trim()) {
+      const q = searchText.toLowerCase();
+      filtered = filtered.filter((item) =>
+        (item.title + item.creator + item.description)
+          .toLowerCase()
+          .includes(q)
+      );
+    }
+
+    if (sortType === "new") {
+      filtered.sort(
+        (a, b) => parseDate(b.publishedAt) - parseDate(a.publishedAt)
+      );
+    } else {
+      filtered.sort(
+        (a, b) => parseDate(a.publishedAt) - parseDate(b.publishedAt)
+      );
+    }
+
+    setDisplayData(filtered);
+  }, [data, sortType, searchText, isRandom]);
+
+  /* =========================
+     ランダム
+  ========================= */
+  const handleShuffle = () => {
+    let base = [...data];
+
+    // 検索中なら検索結果だけシャッフル
+    if (searchText.trim()) {
+      const q = searchText.toLowerCase();
+      base = base.filter((item) =>
+        (item.title + item.creator + item.description)
+          .toLowerCase()
+          .includes(q)
+      );
+    }
+
+    setDisplayData(shuffleArray(base));
+    setIsRandom(true);
+  };
+
+  /* =========================
+     ソート変更
+  ========================= */
+  const handleSortChange = (value: "new" | "old") => {
+    setSortType(value);
+    setIsRandom(false);
+  };
+
+  /* =========================
+     検索変更
+  ========================= */
+  const handleSearchChange = (value: string) => {
+    setSearchText(value);
+    setIsRandom(false);
+  };
 
   return (
-    <main style={{ padding: "40px" }}>
-      <h1>楽曲一覧（ルーキー）</h1>
+    <div className="p-4 sm:p-6 flex flex-col items-center">
+      {/* ヘッダー */}
+      <div className="text-center mb-8 w-full max-w-[760px]">
+        <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold">
+          楽曲一覧 ルーキー
+        </h1>
 
-      <div style={{
-        display: "grid",
-        gridTemplateColumns: "repeat(auto-fill, minmax(250px, 1fr))",
-        gap: "20px"
-      }}>
-        {videos.map((video: any, index: number) => (
-          <VideoCard key={index} video={video} />
-        ))}
+        <p className="text-xs sm:text-sm text-gray-600 mt-2">
+          「{CONFIG.event.name}」のルーキー参加楽曲を掲載しています。
+        </p>
+
+        <div className="mt-4 border-b border-gray-200 w-full" />
       </div>
-    </main>
-  )
+
+      {/* 検索 */}
+      {!loading && (
+        <div className="w-full max-w-[760px] mb-4 flex">
+          <input
+            type="text"
+            placeholder="検索"
+            value={searchText}
+            onChange={(e) => handleSearchChange(e.target.value)}
+            className="w-48 border rounded px-2 py-1 text-sm"
+          />
+        </div>
+      )}
+
+      {/* 操作バー */}
+      {!loading && data.length > 0 && (
+        <div className="w-full max-w-[760px] flex items-center justify-between mb-6">
+          <div className="flex items-center gap-2">
+            <select
+              value={isRandom ? "random" : sortType}
+              onChange={(e) => {
+                const val = e.target.value;
+                if (val === "random") return;
+                handleSortChange(val as "new" | "old");
+              }}
+              className="border rounded px-2 py-1 text-sm"
+            >
+              {isRandom && <option value="random">ランダム</option>}
+              <option value="new">新しい順</option>
+              <option value="old">古い順</option>
+            </select>
+
+            <button
+              onClick={handleShuffle}
+              className="px-2 py-1 text-sm rounded border active:scale-95 active:bg-gray-100 transition"
+            >
+              ランダムに並び替え
+            </button>
+          </div>
+
+          <div className="text-sm text-gray-600">
+            {displayData.length}件
+          </div>
+        </div>
+      )}
+
+      {/* Loading */}
+      {loading && (
+        <div className="flex flex-col gap-6 items-center w-full">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <SkeletonCard key={i} />
+          ))}
+        </div>
+      )}
+
+      {/* Empty */}
+      {!loading && displayData.length === 0 && (
+        <div className="text-center py-20 text-gray-600 w-full max-w-[760px]">
+          該当する動画がありません。
+        </div>
+      )}
+
+      {/* Content */}
+      {!loading && displayData.length > 0 && (
+        <div className="flex flex-col gap-6 items-center w-full">
+          {displayData.map((item, i) => (
+            <div
+              key={i}
+              className="group w-full max-w-[760px] rounded-xl bg-white p-4 shadow-sm hover:shadow-md transition"
+            >
+              <div className="flex gap-4">
+                <a
+                  href={item.videoUrl}
+                  target="_blank"
+                  className="w-40 h-24 flex-shrink-0 overflow-hidden rounded-lg"
+                >
+                  <img
+                    src={item.thumbnailUrl}
+                    className="w-full h-full object-cover group-hover:scale-105 transition"
+                  />
+                </a>
+
+                <div className="flex flex-col flex-1 min-w-0">
+                  <a href={item.videoUrl} target="_blank">
+                    <h2 className="text-base sm:text-lg font-bold leading-snug line-clamp-2 group-hover:underline">
+                      {item.title}
+                    </h2>
+                  </a>
+
+                  <p className="text-sm text-gray-700 font-medium mt-1 truncate">
+                    {item.creator}
+                  </p>
+
+                  <p className="text-xs text-gray-500 mt-1">
+                    {formatDate(item.publishedAt)}
+                  </p>
+
+                  <p className="text-sm text-gray-600 mt-2 line-clamp-2">
+                    {cleanDescription(item.description)}
+                  </p>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
 }

--- a/2026spring/frontend/src/components/Navigation.tsx
+++ b/2026spring/frontend/src/components/Navigation.tsx
@@ -58,15 +58,15 @@ export default function Navigation({ children }: { children: React.ReactNode }) 
           <li><Link href="/details/derivative" onClick={closeDrawer}><Layout className="w-4 h-4 mr-3 text-slate-400" /> 二次創作参加方法</Link></li>
 
           <li className="menu-title mt-4 text-skyblue font-bold tracking-widest text-xs uppercase">投稿作品</li>
-          <li><Link href="/submissions/songs/opening" onClick={closeDrawer}><Music className="w-4 h-4 mr-3 text-slate-400" /> 楽曲一覧 オープニング</Link></li>
           <li><Link href="/submissions/songs/rookie" onClick={closeDrawer}><Music className="w-4 h-4 mr-3 text-slate-400" /> 楽曲一覧 ルーキー</Link></li>
-          <li><Link href="/submissions/songs/extra" onClick={closeDrawer}><Music className="w-4 h-4 mr-3 text-slate-400" /> 楽曲一覧 エクストラ</Link></li>
+          <li><Link href="/submissions/songs/opening" onClick={closeDrawer}><Music className="w-4 h-4 mr-3 text-slate-400" /> 楽曲一覧 opステージ</Link></li>
+          <li><Link href="/submissions/songs/extra" onClick={closeDrawer}><Music className="w-4 h-4 mr-3 text-slate-400" /> 楽曲一覧 exステージ</Link></li>
           
           <li className="menu-title mt-4 text-cherry font-bold tracking-widest text-xs uppercase">人気投票</li>
           <li><Link href="/submissions/vote/preliminaries" onClick={closeDrawer}><Vote className="w-4 h-4 mr-3 text-slate-400" /> 人気投票 予選</Link></li>
           <li><Link href="/submissions/vote/semifinals" onClick={closeDrawer}><Vote className="w-4 h-4 mr-3 text-slate-400" /> 人気投票 準決勝</Link></li>
           <li><Link href="/submissions/vote/finals" onClick={closeDrawer}><Vote className="w-4 h-4 mr-3 text-slate-400" /> 人気投票 決勝</Link></li>
-          <li><Link href="/submissions/vote/extra" onClick={closeDrawer}><Vote className="w-4 h-4 mr-3 text-slate-400" /> 人気投票 エクストラ</Link></li>
+          <li><Link href="/submissions/vote/extra" onClick={closeDrawer}><Vote className="w-4 h-4 mr-3 text-slate-400" /> 人気投票 exステージ</Link></li>
 
           <li className="menu-title mt-4 text-yellow-500 font-bold tracking-widest text-xs uppercase">二次創作</li>
           <li><Link href="/derivative/streams" onClick={closeDrawer}><Star className="w-4 h-4 mr-3 text-slate-400" /> 紹介配信</Link></li>

--- a/2026spring/frontend/src/components/Navigation.tsx
+++ b/2026spring/frontend/src/components/Navigation.tsx
@@ -58,6 +58,7 @@ export default function Navigation({ children }: { children: React.ReactNode }) 
           <li><Link href="/details/derivative" onClick={closeDrawer}><Layout className="w-4 h-4 mr-3 text-slate-400" /> 二次創作参加方法</Link></li>
 
           <li className="menu-title mt-4 text-skyblue font-bold tracking-widest text-xs uppercase">投稿作品</li>
+          <li><Link href="/submissions/songs/opening" onClick={closeDrawer}><Music className="w-4 h-4 mr-3 text-slate-400" /> 楽曲一覧 オープニング</Link></li>
           <li><Link href="/submissions/songs/rookie" onClick={closeDrawer}><Music className="w-4 h-4 mr-3 text-slate-400" /> 楽曲一覧 ルーキー</Link></li>
           <li><Link href="/submissions/songs/extra" onClick={closeDrawer}><Music className="w-4 h-4 mr-3 text-slate-400" /> 楽曲一覧 エクストラ</Link></li>
           

--- a/2026spring/frontend/src/config/config.ts
+++ b/2026spring/frontend/src/config/config.ts
@@ -32,8 +32,25 @@ export const CONFIG = {
     name: "list",
   },
 
+  videosheets: {
+    spreadsheetId: "1lZN68Ojwz1f_x2KEU_ukACzAMDIZUWurV6LI3F3YKj0",
+
+    rookie: {
+      name: "rookie",
+    },
+
+    op: {
+      name: "op",
+    },
+
+    ex: {
+      name: "ex",
+    },
+  },
+
   images: {
     defaultIllustration:
       "https://assets.st-note.com/production/uploads/images/234735453/rectangle_large_type_2_a6d07134e08c70b754fc5c0154e88edf.png?width=1280",
   },
 };
+

--- a/2026spring/frontend/src/lib/fetchSheet.ts
+++ b/2026spring/frontend/src/lib/fetchSheet.ts
@@ -62,3 +62,39 @@ export async function fetchNoteSheet(
     userProfileImageUrl: row["user_profile_img_url"] ?? "",
   }));
 }
+
+// lib/fetchSheet.ts に追加
+
+export type VideoSheetItem = {
+  videoId: string;
+  title: string;
+  creatorId: string;
+  creator: string;
+  publishedAt: string;
+  description: string;
+  videoUrl: string;
+  thumbnailUrl: string;
+};
+
+export async function fetchVideosSheet(
+  sheetName: string
+): Promise<VideoSheetItem[]> {
+  const url = `https://opensheet.elk.sh/${CONFIG.videosheets.spreadsheetId}/${sheetName}`;
+
+  const res = await fetch(url, {
+    next: { revalidate: 60 },
+  });
+
+  const data = await res.json();
+
+  return data.map((row: any) => ({
+    videoId: row["動画ID"] ?? "",
+    title: row["タイトル"] ?? "",
+    creatorId: row["投稿者ID"] ?? "",
+    creator: row["投稿者名"] ?? "",
+    publishedAt: (row["投稿日時"] ?? "").replace(/^'/, ""),
+    description: row["概要欄"] ?? "",
+    videoUrl: row["URL"] ?? "",
+    thumbnailUrl: row["サムネイルURL"] ?? "",
+  }));
+}


### PR DESCRIPTION
## 概要

OP楽曲一覧ページがないので作成してみる

## 関連Issue
- Closes #50 

## 変更内容

- OP楽曲一覧ページの追加
- OP楽曲一覧取得のためのAPI追加
- noteのページの構成を合わせて微修正

## 動作確認

- ローカルで表示確認

## 影響範囲

## 補足

- こんな感じにしてみました。
<img width="1395" height="748" alt="スクリーンショット 2026-04-12 22 56 57" src="https://github.com/user-attachments/assets/fb2ea8e6-68b6-4f6b-b08c-008a61048f9f" />