### PR TITLE
トップページに二次創作提出フォームへのリンクを貼る

### DIFF
--- a/2026spring/frontend/src/components/Rules.tsx
+++ b/2026spring/frontend/src/components/Rules.tsx
@@ -488,7 +488,16 @@ export default function Rules() {
               のタグをつけてください。
             </li>
             <li>
-              指定のGoogleフォーム（後日公開予定）に投稿内容を入力してください。本サイトに反映されます。投稿者以外が入力しても構いません。
+              指定の
+              <a
+                href="https://forms.gle/VXkmUERYv2GABPSR9"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-skyblue font-medium text-fg-brand hover:underline"
+              >
+                Googleフォーム
+              </a>
+              に投稿内容を入力してください。本サイトに反映されます。投稿者以外が入力しても構いません。
               <br />※ note投稿者はGoogleフォームへの回答は不要です。
             </li>
             <li>

--- a/2026spring/frontend/src/components/Rules.tsx
+++ b/2026spring/frontend/src/components/Rules.tsx
@@ -490,7 +490,7 @@ export default function Rules() {
             <li>
               指定の
               <a
-                href="https://forms.gle/VXkmUERYv2GABPSR9"
+                href="https://forms.gle/NofKH1UQjiiiHHYe7"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-skyblue font-medium text-fg-brand hover:underline"


### PR DESCRIPTION
## 概要

トップページに二次創作提出フォームへのリンクを貼る

## 関連Issue

 - #80 

## 動作確認

リンクを押してフォームに飛ぶことを確認済み
