### PR TITLE
作品投稿期間を変更

### DIFF
--- a/2026spring/frontend/src/components/Schedule.tsx
+++ b/2026spring/frontend/src/components/Schedule.tsx
@@ -2,7 +2,7 @@ export default function Schedule() {
   const scheduleItems = [
     {
       title: "作品投稿期間",
-      date: "2026年4月22日(水) 17:00 〜 4月24日(金) 20:00",
+      date: "2026年4月22日(水) 17:00 〜 4月25日(土) 04:00",
       description: "本祭の楽曲投稿期間。指定タグをロックして投稿してください。",
       color: "step-primary", // mint
     },


### PR DESCRIPTION
## 概要

作品投稿期間終了日時を変更

## 関連Issue

 - #87 

## 変更内容

投稿期間終了日を4/24(金) 20:00 -> 4/25(土) 04:00 に変更

## 動作確認