### PR TITLE
Cache-Controlの適用

### DIFF
--- a/2026spring/frontend/next.config.ts
+++ b/2026spring/frontend/next.config.ts
@@ -62,6 +62,36 @@ const nextConfig: NextConfig = {
           },
         ],
       },
+      // 投稿作品ページは1時間キャッシュ
+      {
+        source: "/submissions/songs/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=3600, must-revalidate",
+          },
+        ],
+      },
+      // 投票ページは1時間キャッシュ
+      {
+        source: "/submissions/vote/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=3600, must-revalidate",
+          },
+        ],
+      },
+      // 二次創作提出ページは1時間キャッシュ
+      {
+        source: "/derivative/Postingform",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=3600, must-revalidate",
+          },
+        ],
+      },
       // その他の HTMLページは常に最新を優先（必要ならここを s-maxage 等に調整）
       {
         source: "/(.*)",

--- a/2026spring/frontend/next.config.ts
+++ b/2026spring/frontend/next.config.ts
@@ -1,7 +1,69 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async headers() {
+    return [
+      // ビルド済み静的アセット（ハッシュ付き）: 長期キャッシュ
+      {
+        source: "/_next/static/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=31536000, immutable",
+          },
+        ],
+      },
+      // next/image の処理対象や手動配置した images ディレクトリ
+      {
+        source: "/_next/image/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=31536000, immutable",
+          },
+        ],
+      },
+      {
+        source: "/images/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=31536000, immutable",
+          },
+        ],
+      },
+      // 静的画像ファイル拡張子マッチ（public 配下など）
+      {
+        source: "/:path*.(png|jpg|jpeg|gif|webp|avif|svg)",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=31536000, immutable",
+          },
+        ],
+      },
+      // API はキャッシュしない
+      {
+        source: "/api/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "no-store",
+          },
+        ],
+      },
+      // HTMLページは常に最新を優先（必要ならここを s-maxage 等に調整）
+      {
+        source: "/(.*)",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "no-cache, must-revalidate, max-age=0",
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/2026spring/frontend/next.config.ts
+++ b/2026spring/frontend/next.config.ts
@@ -52,7 +52,17 @@ const nextConfig: NextConfig = {
           },
         ],
       },
-      // HTMLページは常に最新を優先（必要ならここを s-maxage 等に調整）
+      // トップページは常に最新を優先
+      {
+        source: "/",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "max-age=0, must-revalidate",
+          },
+        ],
+      },
+      // その他の HTMLページは常に最新を優先（必要ならここを s-maxage 等に調整）
       {
         source: "/(.*)",
         headers: [


### PR DESCRIPTION
## 概要

next.config.jsでファイルのヘッダーにcache-controlを設定

## 関連Issue

 - #119 

## 変更内容

- ビルド済み静的アセット、画像は1年キャッシュ
- 投稿作品、投票、二次創作作品提出ページは1時間キャッシュ
- API、トップページ、その他はキャッシュしない

## 動作確認