### PR TITLE
Perf/125 ssg

### DIFF
--- a/2026spring/frontend/src/app/submissions/vote/preliminaries/VoteContent.tsx
+++ b/2026spring/frontend/src/app/submissions/vote/preliminaries/VoteContent.tsx
@@ -114,11 +114,14 @@ function SkeletonCard() {
 /* =========================
    Page
 ========================= */
-export default function VoteContent() {
+export default function VoteContent({ initialSongs }: { initialSongs: any[] }) {
   const phase = getCurrentPhase()
   const viewPhase = getViewPhase(phase)
 
-  const [videos, setVideos] = useState<Video[]>([])
+  // const [videos, setVideos] = useState<Video[]>([])
+  const [videos, setVideos] = useState(initialSongs)
+  const mappedVideos = videos
+
   const [votes, setVotes] = useState<Vote[]>([])
   const [ranks, setRanks] = useState<Rank[]>([])
   const [loading, setLoading] = useState(true)
@@ -133,23 +136,23 @@ export default function VoteContent() {
   ========================= */
   useEffect(() => {
     Promise.all([
-      fetch("/api/submissions/vote/preliminaries/songs").then(r => r.json()),
+      // fetch("/api/submissions/vote/preliminaries/songs").then(r => r.json()),
       fetch("/api/submissions/vote/preliminaries/forms").then(r => r.json()),
       fetch("/api/submissions/vote/preliminaries/ranks").then(r => r.json()),
-    ]).then(([videoRes, voteRes, rankRes]) => {
+    ]).then(([voteRes, rankRes]) => {
 
-      const mappedVideos: Video[] = videoRes.map((v: any) => ({
-        title: v.title,
-        creator: v.creator,
-        videoUrl: v.videoUrl,
-        thumbnailUrl: v.thumbnailUrl,
-        publishedAt: v.publishedAt,
-        description: v.description,
-        group: Number(v.group || 0),
-        videoId: v.videoId,
-      }))
+      // const mappedVideos: Video[] = videoRes.map((v: any) => ({
+      //   title: v.title,
+      //   creator: v.creator,
+      //   videoUrl: v.videoUrl,
+      //   thumbnailUrl: v.thumbnailUrl,
+      //   publishedAt: v.publishedAt,
+      //   description: v.description,
+      //   group: Number(v.group || 0),
+      //   videoId: v.videoId,
+      // }))
 
-      setVideos(mappedVideos)
+      // setVideos(mappedVideos)
       setVotes(voteRes)
       setRanks(rankRes)
 

--- a/2026spring/frontend/src/app/submissions/vote/preliminaries/VoteContent.tsx
+++ b/2026spring/frontend/src/app/submissions/vote/preliminaries/VoteContent.tsx
@@ -136,23 +136,9 @@ export default function VoteContent({ initialSongs }: { initialSongs: any[] }) {
   ========================= */
   useEffect(() => {
     Promise.all([
-      // fetch("/api/submissions/vote/preliminaries/songs").then(r => r.json()),
       fetch("/api/submissions/vote/preliminaries/forms").then(r => r.json()),
       fetch("/api/submissions/vote/preliminaries/ranks").then(r => r.json()),
     ]).then(([voteRes, rankRes]) => {
-
-      // const mappedVideos: Video[] = videoRes.map((v: any) => ({
-      //   title: v.title,
-      //   creator: v.creator,
-      //   videoUrl: v.videoUrl,
-      //   thumbnailUrl: v.thumbnailUrl,
-      //   publishedAt: v.publishedAt,
-      //   description: v.description,
-      //   group: Number(v.group || 0),
-      //   videoId: v.videoId,
-      // }))
-
-      // setVideos(mappedVideos)
       setVotes(voteRes)
       setRanks(rankRes)
 

--- a/2026spring/frontend/src/app/submissions/vote/preliminaries/page.tsx
+++ b/2026spring/frontend/src/app/submissions/vote/preliminaries/page.tsx
@@ -1,10 +1,15 @@
 import { Suspense } from "react"
 import VoteContent from "./VoteContent"
+import { getPreliminarySongs } from "@/lib/votes"
 
-export default function Page() {
+export default async function Page() {
+  // songsデータだけサーバーサイドで事前に取得
+  const initialSongs = await getPreliminarySongs();
+
   return (
     <Suspense fallback={<div className="p-4">Loading...</div>}>
-      <VoteContent />
+      {/* 楽曲データだけ先に渡す */}
+      <VoteContent initialSongs={initialSongs} />
     </Suspense>
   )
 }

--- a/2026spring/frontend/src/app/submissions/vote/semifinals/VoteContent.tsx
+++ b/2026spring/frontend/src/app/submissions/vote/semifinals/VoteContent.tsx
@@ -114,11 +114,13 @@ function SkeletonCard() {
 /* =========================
    Page
 ========================= */
-export default function VoteContent() {
+export default function VoteContent({ initialSongs }: { initialSongs: any[] }) {
   const phase = getCurrentPhase()
   const viewPhase = getViewPhase(phase)
 
-  const [videos, setVideos] = useState<Video[]>([])
+  // const [videos, setVideos] = useState<Video[]>([])
+  const [videos, setVideos] = useState(initialSongs)
+  const mappedVideos = videos
   const [votes, setVotes] = useState<Vote[]>([])
   const [ranks, setRanks] = useState<Rank[]>([])
   const [loading, setLoading] = useState(true)
@@ -133,23 +135,23 @@ export default function VoteContent() {
   ========================= */
   useEffect(() => {
     Promise.all([
-      fetch("/api/submissions/vote/semifinals/songs").then(r => r.json()),
+      // fetch("/api/submissions/vote/semifinals/songs").then(r => r.json()),
       fetch("/api/submissions/vote/semifinals/forms").then(r => r.json()),
       fetch("/api/submissions/vote/semifinals/ranks").then(r => r.json()),
-    ]).then(([videoRes, voteRes, rankRes]) => {
+    ]).then(([voteRes, rankRes]) => {
 
-      const mappedVideos: Video[] = videoRes.map((v: any) => ({
-        title: v.title,
-        creator: v.creator,
-        videoUrl: v.videoUrl,
-        thumbnailUrl: v.thumbnailUrl,
-        publishedAt: v.publishedAt,
-        description: v.description,
-        group: Number(v.group || 0),
-        videoId: v.videoId,
-      }))
+      // const mappedVideos: Video[] = videoRes.map((v: any) => ({
+      //   title: v.title,
+      //   creator: v.creator,
+      //   videoUrl: v.videoUrl,
+      //   thumbnailUrl: v.thumbnailUrl,
+      //   publishedAt: v.publishedAt,
+      //   description: v.description,
+      //   group: Number(v.group || 0),
+      //   videoId: v.videoId,
+      // }))
 
-      setVideos(mappedVideos)
+      // setVideos(mappedVideos)
       setVotes(voteRes)
       setRanks(rankRes)
 

--- a/2026spring/frontend/src/app/submissions/vote/semifinals/VoteContent.tsx
+++ b/2026spring/frontend/src/app/submissions/vote/semifinals/VoteContent.tsx
@@ -135,23 +135,9 @@ export default function VoteContent({ initialSongs }: { initialSongs: any[] }) {
   ========================= */
   useEffect(() => {
     Promise.all([
-      // fetch("/api/submissions/vote/semifinals/songs").then(r => r.json()),
       fetch("/api/submissions/vote/semifinals/forms").then(r => r.json()),
       fetch("/api/submissions/vote/semifinals/ranks").then(r => r.json()),
     ]).then(([voteRes, rankRes]) => {
-
-      // const mappedVideos: Video[] = videoRes.map((v: any) => ({
-      //   title: v.title,
-      //   creator: v.creator,
-      //   videoUrl: v.videoUrl,
-      //   thumbnailUrl: v.thumbnailUrl,
-      //   publishedAt: v.publishedAt,
-      //   description: v.description,
-      //   group: Number(v.group || 0),
-      //   videoId: v.videoId,
-      // }))
-
-      // setVideos(mappedVideos)
       setVotes(voteRes)
       setRanks(rankRes)
 

--- a/2026spring/frontend/src/app/submissions/vote/semifinals/page.tsx
+++ b/2026spring/frontend/src/app/submissions/vote/semifinals/page.tsx
@@ -1,10 +1,15 @@
 import { Suspense } from "react"
 import VoteContent from "./VoteContent"
+import { getSemifinalSongs } from "@/lib/votes"
 
-export default function Page() {
+export default async function Page() {
+  // songsデータだけサーバーサイドで事前に取得
+  const initialSongs = await getSemifinalSongs();
+
   return (
     <Suspense fallback={<div className="p-4">Loading...</div>}>
-      <VoteContent />
+      {/* 楽曲データだけ先に渡す */}
+      <VoteContent initialSongs={initialSongs} />
     </Suspense>
   )
 }

--- a/2026spring/frontend/src/lib/fetchSheet.ts
+++ b/2026spring/frontend/src/lib/fetchSheet.ts
@@ -118,7 +118,7 @@ export async function fetchGroupedVideosSheet(
   const url = `https://opensheet.elk.sh/${spreadsheetId}/${sheetName}`;
 
   const res = await fetch(url, {
-    next: { revalidate: 60 },
+    next: { revalidate: 86400 },
   });
 
   const data = await res.json();

--- a/2026spring/frontend/src/lib/fetchSheet.ts
+++ b/2026spring/frontend/src/lib/fetchSheet.ts
@@ -118,7 +118,7 @@ export async function fetchGroupedVideosSheet(
   const url = `https://opensheet.elk.sh/${spreadsheetId}/${sheetName}`;
 
   const res = await fetch(url, {
-    next: { revalidate: 86400 },
+    next: { revalidate: false },
   });
 
   const data = await res.json();

--- a/2026spring/frontend/src/lib/fetchSheet.ts
+++ b/2026spring/frontend/src/lib/fetchSheet.ts
@@ -12,7 +12,9 @@ export type FanficSheetItem = {
   publishedAt: string;
 };
 
-export async function fetchFanficSheet(sheetName: string): Promise<FanficSheetItem[]> {
+export async function fetchFanficSheet(
+  sheetName: string,
+): Promise<FanficSheetItem[]> {
   const url = `https://opensheet.elk.sh/${CONFIG.fanficsheets.spreadsheetId}/${sheetName}`;
 
   const res = await fetch(url);
@@ -42,7 +44,7 @@ export type NoteSheetItem = {
 };
 
 export async function fetchNoteSheet(
-  sheetName: string
+  sheetName: string,
 ): Promise<NoteSheetItem[]> {
   const url = `https://opensheet.elk.sh/${CONFIG.notesheets.spreadsheetId}/${sheetName}`;
 
@@ -77,7 +79,7 @@ export type VideoSheetItem = {
 };
 
 export async function fetchVideosSheet(
-  sheetName: string
+  sheetName: string,
 ): Promise<VideoSheetItem[]> {
   const url = `https://opensheet.elk.sh/${CONFIG.videosheets.spreadsheetId}/${sheetName}`;
 
@@ -113,12 +115,12 @@ export type GroupedVideoSheetItem = {
 
 export async function fetchGroupedVideosSheet(
   spreadsheetId: string,
-  sheetName: string
+  sheetName: string,
 ): Promise<GroupedVideoSheetItem[]> {
   const url = `https://opensheet.elk.sh/${spreadsheetId}/${sheetName}`;
 
   const res = await fetch(url, {
-    next: { revalidate: false },
+    next: { revalidate: 86400 }, // 24時間キャッシュ
   });
 
   const data = await res.json();
@@ -144,7 +146,7 @@ export type VoteSheetItem = {
 };
 
 export async function fetchVotesSheet(
-  sheetName: string
+  sheetName: string,
 ): Promise<VoteSheetItem[]> {
   const url = `https://opensheet.elk.sh/${CONFIG.voteformssheets.spreadsheetId}/${sheetName}`;
 
@@ -169,7 +171,7 @@ export type RankingItem = {
 };
 
 export async function fetchRankingSheet(
-  sheetName: string
+  sheetName: string,
 ): Promise<RankingItem[]> {
   const url = `https://opensheet.elk.sh/${CONFIG.rankingsheets.spreadsheetId}/${sheetName}`;
 

--- a/2026spring/frontend/src/lib/votes.ts
+++ b/2026spring/frontend/src/lib/votes.ts
@@ -1,0 +1,25 @@
+// lib/votes.ts
+import { fetchGroupedVideosSheet } from "@/lib/fetchSheet";
+import { CONFIG } from "@/config/config";
+
+export async function getPreliminarySongs() {
+  // キャッシュを有効にするために fetch を使うか、unstable_cache を検討してください
+  const items = await fetchGroupedVideosSheet(
+    CONFIG.groupedvideosheets.spreadsheetId,
+    CONFIG.groupedvideosheets.rookie.name
+  );
+
+  // 転送量を減らすため、サーバーサイドで map を済ませる
+  return items
+    .filter((v) => v.videoUrl)
+    .map((v) => ({
+      title: v.title,
+      creator: v.creator,
+      videoUrl: v.videoUrl,
+      thumbnailUrl: v.thumbnailUrl,
+      publishedAt: v.publishedAt,
+      description: v.description,
+      group: Number(v.group || 0),
+      videoId: v.videoId,
+    }));
+}

--- a/2026spring/frontend/src/lib/votes.ts
+++ b/2026spring/frontend/src/lib/votes.ts
@@ -42,3 +42,24 @@ export async function getSemifinalSongs() {
       videoId: v.videoId,
     }));
 }
+
+export async function getFinalSongs() {
+  const items = await fetchGroupedVideosSheet(
+    CONFIG.videosheets_final.spreadsheetId,
+    CONFIG.videosheets_final.rookie.name
+  );
+
+  // 転送量を減らすため、サーバーサイドで map を済ませる
+  return items
+    .filter((v) => v.videoUrl)
+    .map((v) => ({
+      title: v.title,
+      creator: v.creator,
+      videoUrl: v.videoUrl,
+      thumbnailUrl: v.thumbnailUrl,
+      publishedAt: v.publishedAt,
+      description: v.description,
+      group: Number(v.group || 0),
+      videoId: v.videoId,
+    }));
+}

--- a/2026spring/frontend/src/lib/votes.ts
+++ b/2026spring/frontend/src/lib/votes.ts
@@ -3,10 +3,29 @@ import { fetchGroupedVideosSheet } from "@/lib/fetchSheet";
 import { CONFIG } from "@/config/config";
 
 export async function getPreliminarySongs() {
-  // キャッシュを有効にするために fetch を使うか、unstable_cache を検討してください
   const items = await fetchGroupedVideosSheet(
     CONFIG.groupedvideosheets.spreadsheetId,
     CONFIG.groupedvideosheets.rookie.name
+  );
+
+  // 転送量を減らすため、サーバーサイドで map を済ませる
+  return items
+    .filter((v) => v.videoUrl)
+    .map((v) => ({
+      title: v.title,
+      creator: v.creator,
+      videoUrl: v.videoUrl,
+      thumbnailUrl: v.thumbnailUrl,
+      publishedAt: v.publishedAt,
+      description: v.description,
+      group: Number(v.group || 0),
+      videoId: v.videoId,
+    }));
+}
+export async function getSemifinalSongs() {
+  const items = await fetchGroupedVideosSheet(
+    CONFIG.groupedvideosheets_semifinal.spreadsheetId,
+    CONFIG.groupedvideosheets_semifinal.rookie.name
   );
 
   // 転送量を減らすため、サーバーサイドで map を済ませる


### PR DESCRIPTION
### 背景・目的
投票ページ内での楽曲データ取得をCSRからSSG/ISRに移行
### 修正内容
VoteContent.tsx内でAPI(/api/submissions/vote/semifinals/song)をフェッチしないようにコード修正

### 確認事項
- localhost:3000でデベロッパーツールを確認し、楽曲データ取得APIリクエストが消えていることを確認
- ページの挙動自体は以前と変わらないことを確認