### PR TITLE
決勝ルール変更

### DIFF
--- a/2026spring/frontend/src/components/Rules.tsx
+++ b/2026spring/frontend/src/components/Rules.tsx
@@ -370,7 +370,11 @@ export default function Rules() {
             <li>予選通過作品を改めて10作品単位のSelectionに分けます。</li>
             <li>
               予選と同様に人気投票をして
-              <strong>上位2曲を準決勝通過</strong>とします。
+              <strong>
+                <s>上位2曲</s>
+                <span className="text-cherry">上位1曲</span>を準決勝通過
+              </strong>
+              とします。
             </li>
             <li>スコアは全曲が公開されます。</li>
           </ul>

--- a/2026spring/frontend/src/components/Schedule.tsx
+++ b/2026spring/frontend/src/components/Schedule.tsx
@@ -16,7 +16,7 @@ export default function Schedule() {
       title: "準決勝(Selection)",
       date: "2026年5月11日(月) 〜 5月17日(日)",
       description:
-        "各Discの予選順位に基づいて振り分け。各Selection上位2作品決勝進出",
+        "各Discの予選順位に基づいて振り分け。各Selection上位1作品決勝進出",
       color: "step-accent", // cherry
     },
     {


### PR DESCRIPTION
## 概要

準決勝から決勝へは上位２曲から上位１曲が進出するように記述を変更

## 関連Issue

 - #131 