### PR TITLE
決勝とexの投票フォーム作成

### DIFF
--- a/2026spring/backend/config/settings.yml
+++ b/2026spring/backend/config/settings.yml
@@ -50,10 +50,6 @@ spreadsheets:
     name: "grouped_video_catalog_2026spring_final" # スプレッドシート名
     rookie_sheet: "rookie" # ルーキー参加作品リストシート名
 
-  grouped_video_catalog_ex: # exステージ参加の全ての動画リスト。
-    name: "grouped_video_catalog_2026spring_ex" # スプレッドシート名
-    ex_sheet: "ex" # exステージ作品リストシート名
-
 vote_grouping: # 投票グループ分け関連パラメータ
   random_seed: 42
   group_num: 70

--- a/2026spring/backend/config/settings.yml
+++ b/2026spring/backend/config/settings.yml
@@ -46,9 +46,13 @@ spreadsheets:
     forms_result: "Forms_result" # フォーム回答結果シート名（二次創作作品提出フォームの回答をリンクさせるシート）
     for_check: "二次創作作品情報確認用" # 二次創作作品情報確認用シート名
 
-  video_catalog_final: # 決勝参加の全ての動画リスト。
-    name: "video_catalog_2026spring_final" # スプレッドシート名
+  grouped_video_catalog_final: # 決勝参加の全ての動画リスト。
+    name: "grouped_video_catalog_2026spring_final" # スプレッドシート名
     rookie_sheet: "rookie" # ルーキー参加作品リストシート名
+
+  grouped_video_catalog_ex: # exステージ参加の全ての動画リスト。
+    name: "grouped_video_catalog_2026spring_ex" # スプレッドシート名
+    ex_sheet: "ex" # exステージ作品リストシート名
 
 vote_grouping: # 投票グループ分け関連パラメータ
   random_seed: 42
@@ -74,8 +78,8 @@ vote_form: # 投票フォーム関連パラメータ
     title: "本当のルーキー祭り2026春_Selection."
     item_title: "好きな作品を教えてください。"
   final: # 決勝
-    title: "本当のルーキー祭り2026春_Best"
+    title: "本当のルーキー祭り2026春_Best."
     item_title: "好きな作品を教えてください。"
   ex: # exステージ
-    title: "本当のルーキー祭り2026春_ex"
+    title: "本当のルーキー祭り2026春_ex."
     item_title: "好きな作品を教えてください。"

--- a/2026spring/backend/scripts/setup_forms.py
+++ b/2026spring/backend/scripts/setup_forms.py
@@ -187,12 +187,12 @@ def load_spreadsheet(config, phase):
         video_spreadsheetname = config["vote_semifinal"]["grouped_video_catalog_semifinal"]["name"]
         video_sheetname = config["vote_semifinal"]["grouped_video_catalog_semifinal"]["rookie_sheet"]
     elif phase == "final":
-        video_spreadsheetname = config["spreadsheets"]["video_catalog_final"]["name"]
-        video_sheetname = config["spreadsheets"]["video_catalog_final"]["rookie_sheet"]
+        video_spreadsheetname = config["spreadsheets"]["grouped_video_catalog_final"]["name"]
+        video_sheetname = config["spreadsheets"]["grouped_video_catalog_final"]["rookie_sheet"]
     elif phase == "ex":
-        video_spreadsheetname = config["spreadsheets"]["video_catalog"]["name"]
-        video_sheetname = config["spreadsheets"]["video_catalog"][f"ex_sheet"]
-    
+        video_spreadsheetname = config["spreadsheets"]["grouped_video_catalog_ex"]["name"]
+        video_sheetname = config["spreadsheets"]["grouped_video_catalog_ex"]["ex_sheet"]
+
     video_sheet = sheet_client.connect_sheet(service_account_credentials_path, video_spreadsheetname, video_sheetname)
     video_data = sheet_client.fetch_sheet_data(video_sheet)
 
@@ -213,28 +213,11 @@ def create_vote_forms(creds, config, df, phase):
     parent_folder_id = os.environ["FORMS_FOLDER_ID"]
     new_folder_id = create_folder(creds, parent_folder_id)
 
-    if phase == "prelim" or phase == "semifinal":
-        # グループIDごとに処理
-        for group_id, group_df in df.groupby("グループID", dropna=True, sort=True):
-            print(f"[INFO]\t処理中 group_id={group_id}, 件数={len(group_df)}")
-            
-            title = f'{config["vote_form"][phase]["title"]}{group_id}'
-            item_title = config["vote_form"][phase]["item_title"]
-
-            # テンプレートフォームをコピー
-            new_form_id = copy_file(creds, template_form_id, title)
-
-            # フォームを共有フォルダに移動
-            move_file_to_folder(creds, new_form_id, new_folder_id)
-
-            # フォームを更新
-            update_vote_form(creds, new_form_id, title, item_title, group_df["タイトル"].tolist())
-
-    elif phase == "final" or phase == "ex":
-        # グループIDがないため、全体で1つのフォームを作成
-        print(f"[INFO]\t処理中 phase={phase}, 件数={len(df)}")
-
-        title = config["vote_form"][phase]["title"]
+    # グループIDごとに処理
+    for group_id, group_df in df.groupby("グループID", dropna=True, sort=True):
+        print(f"[INFO]\t処理中 group_id={group_id}, 件数={len(group_df)}")
+        
+        title = f'{config["vote_form"][phase]["title"]}{group_id}'
         item_title = config["vote_form"][phase]["item_title"]
 
         # テンプレートフォームをコピー
@@ -244,7 +227,7 @@ def create_vote_forms(creds, config, df, phase):
         move_file_to_folder(creds, new_form_id, new_folder_id)
 
         # フォームを更新
-        update_vote_form(creds, new_form_id, title, item_title, df["タイトル"].tolist())
+        update_vote_form(creds, new_form_id, title, item_title, group_df["タイトル"].tolist())
 
 
 def main():

--- a/2026spring/backend/scripts/setup_forms.py
+++ b/2026spring/backend/scripts/setup_forms.py
@@ -190,8 +190,8 @@ def load_spreadsheet(config, phase):
         video_spreadsheetname = config["spreadsheets"]["grouped_video_catalog_final"]["name"]
         video_sheetname = config["spreadsheets"]["grouped_video_catalog_final"]["rookie_sheet"]
     elif phase == "ex":
-        video_spreadsheetname = config["spreadsheets"]["grouped_video_catalog_ex"]["name"]
-        video_sheetname = config["spreadsheets"]["grouped_video_catalog_ex"]["ex_sheet"]
+        video_spreadsheetname = config["vote_grouping"]["grouped_video_catalog"]["name"]
+        video_sheetname = config["vote_grouping"]["grouped_video_catalog"]["ex_sheet"]
 
     video_sheet = sheet_client.connect_sheet(service_account_credentials_path, video_spreadsheetname, video_sheetname)
     video_data = sheet_client.fetch_sheet_data(video_sheet)


### PR DESCRIPTION
## 概要

決勝とexの投票フォーム作成

## 関連Issue

 - #139 

## 変更内容

- video_catalog_2026spring_final -> grouped_video_catalog_2026spring_finalにスプレッドシート名を変更
- video_catalog_2026springにexシートを追加
- 決勝はgrouped_video_catalog_2026spring_finalから投票フォームを作成
- exはvideo_catalog_2026springのexシートから投票フォームを作成

## 動作確認

- grouped_video_catalog_2026spring_finalにダミーデータを書いて、決勝投票フォームが正しく作られることを確認
- video_catalog_2026springのexシートにダミーデータを書いて、ex投票フォームが正しく作られることを確認