### PR TITLE
Perf/136 ssg for forms and ranks

### DIFF
--- a/2026spring/frontend/src/app/submissions/vote/preliminaries/VoteContent.tsx
+++ b/2026spring/frontend/src/app/submissions/vote/preliminaries/VoteContent.tsx
@@ -127,12 +127,9 @@ export default function VoteContent({
   const phase = getCurrentPhase()
   const viewPhase = getViewPhase(phase)
 
-  // const [videos, setVideos] = useState<Video[]>([])
   const [videos, setVideos] = useState(initialSongs)
   const mappedVideos = videos
-  // const [votes, setVotes] = useState<Vote[]>([])
   const [votes, setVotes] = useState(initialForms)
-  // const [ranks, setRanks] = useState<Rank[]>([])
   const [ranks, setRanks] = useState(initialRanks)
   const [loading, setLoading] = useState(true)
 
@@ -145,13 +142,6 @@ export default function VoteContent({
      fetch
   ========================= */
   useEffect(() => {
-    // Promise.all([
-    //   fetch("/api/submissions/vote/preliminaries/forms").then(r => r.json()),
-    //   fetch("/api/submissions/vote/preliminaries/ranks").then(r => r.json()),
-    // ]).then(([voteRes, rankRes]) => {
-    //   setVotes(voteRes)
-    //   setRanks(rankRes)
-
       const groups = [...new Set(mappedVideos.map(v => v.group))].sort((a,b)=>a-b)
 
       const groupParam = searchParams.get("group")

--- a/2026spring/frontend/src/app/submissions/vote/preliminaries/VoteContent.tsx
+++ b/2026spring/frontend/src/app/submissions/vote/preliminaries/VoteContent.tsx
@@ -114,16 +114,26 @@ function SkeletonCard() {
 /* =========================
    Page
 ========================= */
-export default function VoteContent({ initialSongs }: { initialSongs: any[] }) {
+export default function VoteContent({
+  initialSongs,
+  initialForms,
+  initialRanks
+ }: { 
+  initialSongs: any[],
+  initialForms: any[],
+  initialRanks: any[]
+
+ }) {
   const phase = getCurrentPhase()
   const viewPhase = getViewPhase(phase)
 
   // const [videos, setVideos] = useState<Video[]>([])
   const [videos, setVideos] = useState(initialSongs)
   const mappedVideos = videos
-
-  const [votes, setVotes] = useState<Vote[]>([])
-  const [ranks, setRanks] = useState<Rank[]>([])
+  // const [votes, setVotes] = useState<Vote[]>([])
+  const [votes, setVotes] = useState(initialForms)
+  // const [ranks, setRanks] = useState<Rank[]>([])
+  const [ranks, setRanks] = useState(initialRanks)
   const [loading, setLoading] = useState(true)
 
   const [activeGroup, setActiveGroup] = useState<number | null>(null)
@@ -135,12 +145,12 @@ export default function VoteContent({ initialSongs }: { initialSongs: any[] }) {
      fetch
   ========================= */
   useEffect(() => {
-    Promise.all([
-      fetch("/api/submissions/vote/preliminaries/forms").then(r => r.json()),
-      fetch("/api/submissions/vote/preliminaries/ranks").then(r => r.json()),
-    ]).then(([voteRes, rankRes]) => {
-      setVotes(voteRes)
-      setRanks(rankRes)
+    // Promise.all([
+    //   fetch("/api/submissions/vote/preliminaries/forms").then(r => r.json()),
+    //   fetch("/api/submissions/vote/preliminaries/ranks").then(r => r.json()),
+    // ]).then(([voteRes, rankRes]) => {
+    //   setVotes(voteRes)
+    //   setRanks(rankRes)
 
       const groups = [...new Set(mappedVideos.map(v => v.group))].sort((a,b)=>a-b)
 
@@ -154,7 +164,7 @@ export default function VoteContent({ initialSongs }: { initialSongs: any[] }) {
       }
 
       setLoading(false)
-    })
+    // })
   }, [])
 
   /* =========================

--- a/2026spring/frontend/src/app/submissions/vote/preliminaries/page.tsx
+++ b/2026spring/frontend/src/app/submissions/vote/preliminaries/page.tsx
@@ -3,7 +3,6 @@ import VoteContent from "./VoteContent"
 import { getPreliminarySongs, getPreliminaryForms, getPreliminaryRanks } from "@/lib/votes"
 
 export default async function Page() {
-  // songsデータだけサーバーサイドで事前に取得
   const [songs,forms,ranks] = await Promise.all([
     getPreliminarySongs(),
     getPreliminaryForms(),
@@ -12,7 +11,6 @@ export default async function Page() {
 
   return (
     <Suspense fallback={<div className="p-4">Loading...</div>}>
-      {/* 楽曲データだけ先に渡す */}
       <VoteContent 
         initialSongs={songs}
         initialForms={forms}

--- a/2026spring/frontend/src/app/submissions/vote/preliminaries/page.tsx
+++ b/2026spring/frontend/src/app/submissions/vote/preliminaries/page.tsx
@@ -1,15 +1,23 @@
 import { Suspense } from "react"
 import VoteContent from "./VoteContent"
-import { getPreliminarySongs } from "@/lib/votes"
+import { getPreliminarySongs, getPreliminaryForms, getPreliminaryRanks } from "@/lib/votes"
 
 export default async function Page() {
   // songsデータだけサーバーサイドで事前に取得
-  const initialSongs = await getPreliminarySongs();
+  const [songs,forms,ranks] = await Promise.all([
+    getPreliminarySongs(),
+    getPreliminaryForms(),
+    getPreliminaryRanks(),
+  ]) 
 
   return (
     <Suspense fallback={<div className="p-4">Loading...</div>}>
       {/* 楽曲データだけ先に渡す */}
-      <VoteContent initialSongs={initialSongs} />
+      <VoteContent 
+        initialSongs={songs}
+        initialForms={forms}
+        initialRanks={ranks}
+      />
     </Suspense>
   )
 }

--- a/2026spring/frontend/src/app/submissions/vote/semifinals/VoteContent.tsx
+++ b/2026spring/frontend/src/app/submissions/vote/semifinals/VoteContent.tsx
@@ -114,15 +114,25 @@ function SkeletonCard() {
 /* =========================
    Page
 ========================= */
-export default function VoteContent({ initialSongs }: { initialSongs: any[] }) {
+export default function VoteContent({ 
+  initialSongs,
+  initialForms,
+  initialRanks
+ }: { 
+  initialSongs: any[],
+  initialForms: any[],
+  initialRanks: any[]
+ }) {
   const phase = getCurrentPhase()
   const viewPhase = getViewPhase(phase)
 
   // const [videos, setVideos] = useState<Video[]>([])
   const [videos, setVideos] = useState(initialSongs)
   const mappedVideos = videos
-  const [votes, setVotes] = useState<Vote[]>([])
-  const [ranks, setRanks] = useState<Rank[]>([])
+  // const [votes, setVotes] = useState<Vote[]>([])
+  const [votes, setVotes] = useState(initialForms)
+  // const [ranks, setRanks] = useState<Rank[]>([])
+  const [ranks, setRanks] = useState(initialRanks)
   const [loading, setLoading] = useState(true)
 
   const [activeGroup, setActiveGroup] = useState<number | null>(null)
@@ -134,12 +144,12 @@ export default function VoteContent({ initialSongs }: { initialSongs: any[] }) {
      fetch
   ========================= */
   useEffect(() => {
-    Promise.all([
-      fetch("/api/submissions/vote/semifinals/forms").then(r => r.json()),
-      fetch("/api/submissions/vote/semifinals/ranks").then(r => r.json()),
-    ]).then(([voteRes, rankRes]) => {
-      setVotes(voteRes)
-      setRanks(rankRes)
+    // Promise.all([
+    //   fetch("/api/submissions/vote/semifinals/forms").then(r => r.json()),
+    //   fetch("/api/submissions/vote/semifinals/ranks").then(r => r.json()),
+    // ]).then(([voteRes, rankRes]) => {
+    //   setVotes(voteRes)
+    //   setRanks(rankRes)
 
       const groups = [...new Set(mappedVideos.map(v => v.group))].sort((a,b)=>a-b)
 
@@ -153,7 +163,7 @@ export default function VoteContent({ initialSongs }: { initialSongs: any[] }) {
       }
 
       setLoading(false)
-    })
+    // })
   }, [])
 
   /* =========================

--- a/2026spring/frontend/src/app/submissions/vote/semifinals/VoteContent.tsx
+++ b/2026spring/frontend/src/app/submissions/vote/semifinals/VoteContent.tsx
@@ -126,12 +126,9 @@ export default function VoteContent({
   const phase = getCurrentPhase()
   const viewPhase = getViewPhase(phase)
 
-  // const [videos, setVideos] = useState<Video[]>([])
   const [videos, setVideos] = useState(initialSongs)
   const mappedVideos = videos
-  // const [votes, setVotes] = useState<Vote[]>([])
   const [votes, setVotes] = useState(initialForms)
-  // const [ranks, setRanks] = useState<Rank[]>([])
   const [ranks, setRanks] = useState(initialRanks)
   const [loading, setLoading] = useState(true)
 
@@ -144,12 +141,6 @@ export default function VoteContent({
      fetch
   ========================= */
   useEffect(() => {
-    // Promise.all([
-    //   fetch("/api/submissions/vote/semifinals/forms").then(r => r.json()),
-    //   fetch("/api/submissions/vote/semifinals/ranks").then(r => r.json()),
-    // ]).then(([voteRes, rankRes]) => {
-    //   setVotes(voteRes)
-    //   setRanks(rankRes)
 
       const groups = [...new Set(mappedVideos.map(v => v.group))].sort((a,b)=>a-b)
 

--- a/2026spring/frontend/src/app/submissions/vote/semifinals/page.tsx
+++ b/2026spring/frontend/src/app/submissions/vote/semifinals/page.tsx
@@ -1,15 +1,23 @@
 import { Suspense } from "react"
 import VoteContent from "./VoteContent"
-import { getSemifinalSongs } from "@/lib/votes"
+import { getSemifinalSongs, getSemifinalForms, getSemifinalRanks } from "@/lib/votes"
 
 export default async function Page() {
   // songsデータだけサーバーサイドで事前に取得
-  const initialSongs = await getSemifinalSongs();
+  const [songs,forms,ranks] = await Promise.all([
+    getSemifinalSongs(),
+    getSemifinalForms(),
+    getSemifinalRanks(),
+  ]) 
 
   return (
     <Suspense fallback={<div className="p-4">Loading...</div>}>
       {/* 楽曲データだけ先に渡す */}
-      <VoteContent initialSongs={initialSongs} />
+      <VoteContent 
+        initialSongs={songs}
+        initialForms={forms}
+        initialRanks={ranks}
+      />
     </Suspense>
   )
 }

--- a/2026spring/frontend/src/app/submissions/vote/semifinals/page.tsx
+++ b/2026spring/frontend/src/app/submissions/vote/semifinals/page.tsx
@@ -3,7 +3,6 @@ import VoteContent from "./VoteContent"
 import { getSemifinalSongs, getSemifinalForms, getSemifinalRanks } from "@/lib/votes"
 
 export default async function Page() {
-  // songsデータだけサーバーサイドで事前に取得
   const [songs,forms,ranks] = await Promise.all([
     getSemifinalSongs(),
     getSemifinalForms(),
@@ -12,7 +11,6 @@ export default async function Page() {
 
   return (
     <Suspense fallback={<div className="p-4">Loading...</div>}>
-      {/* 楽曲データだけ先に渡す */}
       <VoteContent 
         initialSongs={songs}
         initialForms={forms}

--- a/2026spring/frontend/src/lib/fetchSheet.ts
+++ b/2026spring/frontend/src/lib/fetchSheet.ts
@@ -151,7 +151,7 @@ export async function fetchVotesSheet(
   const url = `https://opensheet.elk.sh/${CONFIG.voteformssheets.spreadsheetId}/${sheetName}`;
 
   const res = await fetch(url, {
-    next: { revalidate: 60 },
+    next: { revalidate: false },
   });
 
   const data = await res.json();
@@ -176,7 +176,7 @@ export async function fetchRankingSheet(
   const url = `https://opensheet.elk.sh/${CONFIG.rankingsheets.spreadsheetId}/${sheetName}`;
 
   const res = await fetch(url, {
-    next: { revalidate: 60 },
+    next: { revalidate: false },
   });
 
   const data = await res.json();

--- a/2026spring/frontend/src/lib/votes.ts
+++ b/2026spring/frontend/src/lib/votes.ts
@@ -22,6 +22,34 @@ export async function getPreliminarySongs() {
       videoId: v.videoId,
     }));
 }
+
+export async function getPreliminaryForms(){
+  const items = await fetchVotesSheet(
+    // CONFIG.voteformssheets.spreadsheetId,
+    CONFIG.voteformssheets.preliminaries.name
+  );
+  return items
+    .filter((f) => f.formUrl)
+    .map((f) => ({
+      group: f.group,
+      formUrl: f.formUrl,
+      mylistUrl: f.mylistUrl,
+      deadline: f.deadline,
+    }));
+
+}
+export async function getPreliminaryRanks(){
+  const items = await fetchRankingSheet(
+    // CONFIG.rankingsheets.spreadsheetId,
+    CONFIG.rankingsheets.preliminaries.name
+  );
+  return items
+    .map((r) => ({
+      videoId: r.videoId,
+      group: r.group,
+      rank: r.rank
+    }));
+}
 export async function getSemifinalSongs() {
   const items = await fetchGroupedVideosSheet(
     CONFIG.groupedvideosheets_semifinal.spreadsheetId,

--- a/2026spring/frontend/src/lib/votes.ts
+++ b/2026spring/frontend/src/lib/votes.ts
@@ -1,5 +1,5 @@
 // lib/votes.ts
-import { fetchGroupedVideosSheet } from "@/lib/fetchSheet";
+import { fetchGroupedVideosSheet, fetchVotesSheet, fetchRankingSheet} from "@/lib/fetchSheet";
 import { CONFIG } from "@/config/config";
 
 export async function getPreliminarySongs() {
@@ -40,6 +40,34 @@ export async function getSemifinalSongs() {
       description: v.description,
       group: Number(v.group || 0),
       videoId: v.videoId,
+    }));
+}
+
+export async function getSemifinalForms(){
+  const items = await fetchVotesSheet(
+    // CONFIG.voteformssheets.spreadsheetId,
+    CONFIG.voteformssheets.semifinals.name
+  );
+  return items
+    .filter((f) => f.formUrl)
+    .map((f) => ({
+      group: f.group,
+      formUrl: f.formUrl,
+      mylistUrl: f.mylistUrl,
+      deadline: f.deadline,
+    }));
+
+}
+export async function getSemifinalRanks(){
+  const items = await fetchRankingSheet(
+    // CONFIG.rankingsheets.spreadsheetId,
+    CONFIG.rankingsheets.semifinals.name
+  );
+  return items
+    .map((r) => ({
+      videoId: r.videoId,
+      group: r.group,
+      rank: r.rank
     }));
 }
 

--- a/2026spring/frontend/src/lib/votes.ts
+++ b/2026spring/frontend/src/lib/votes.ts
@@ -7,8 +7,6 @@ export async function getPreliminarySongs() {
     CONFIG.groupedvideosheets.spreadsheetId,
     CONFIG.groupedvideosheets.rookie.name
   );
-
-  // 転送量を減らすため、サーバーサイドで map を済ませる
   return items
     .filter((v) => v.videoUrl)
     .map((v) => ({
@@ -25,7 +23,6 @@ export async function getPreliminarySongs() {
 
 export async function getPreliminaryForms(){
   const items = await fetchVotesSheet(
-    // CONFIG.voteformssheets.spreadsheetId,
     CONFIG.voteformssheets.preliminaries.name
   );
   return items
@@ -40,7 +37,6 @@ export async function getPreliminaryForms(){
 }
 export async function getPreliminaryRanks(){
   const items = await fetchRankingSheet(
-    // CONFIG.rankingsheets.spreadsheetId,
     CONFIG.rankingsheets.preliminaries.name
   );
   return items
@@ -55,8 +51,6 @@ export async function getSemifinalSongs() {
     CONFIG.groupedvideosheets_semifinal.spreadsheetId,
     CONFIG.groupedvideosheets_semifinal.rookie.name
   );
-
-  // 転送量を減らすため、サーバーサイドで map を済ませる
   return items
     .filter((v) => v.videoUrl)
     .map((v) => ({
@@ -73,7 +67,6 @@ export async function getSemifinalSongs() {
 
 export async function getSemifinalForms(){
   const items = await fetchVotesSheet(
-    // CONFIG.voteformssheets.spreadsheetId,
     CONFIG.voteformssheets.semifinals.name
   );
   return items
@@ -88,7 +81,6 @@ export async function getSemifinalForms(){
 }
 export async function getSemifinalRanks(){
   const items = await fetchRankingSheet(
-    // CONFIG.rankingsheets.spreadsheetId,
     CONFIG.rankingsheets.semifinals.name
   );
   return items
@@ -104,8 +96,6 @@ export async function getFinalSongs() {
     CONFIG.videosheets_final.spreadsheetId,
     CONFIG.videosheets_final.rookie.name
   );
-
-  // 転送量を減らすため、サーバーサイドで map を済ませる
   return items
     .filter((v) => v.videoUrl)
     .map((v) => ({


### PR DESCRIPTION
### 背景・目的
予選・準決勝投票ページ内でのforms, ranks取得処理をSSGに移行

### 修正内容
該当APIが毎回呼び出されないように以下のコードを修正
- src/app/submissions/vote/semifinals/page.tsx
- src/app/submissins/vote/semifinals/VoteContent.tsx
- src/lib/vote.ts  

### 確認事項
localhost:3000でデベロッパーツールを確認し、楽曲データ取得APIリクエストが消えていることを確認
ページの挙動自体は以前と変わらないことを確認