### PR TITLE
トップページの更新

### DIFF
--- a/2026spring/frontend/src/app/page.tsx
+++ b/2026spring/frontend/src/app/page.tsx
@@ -1,15 +1,14 @@
-
-import Hero from "@/components/Hero";
 import About from "@/components/About";
+import Hero from "@/components/Hero";
 import Rules from "@/components/Rules";
 import Schedule from "@/components/Schedule";
 
-import RelatedLinks from "@/components/sections/RelatedLinks";
+import Contact from "@/components/sections/Contact";
 import Crowdfunding from "@/components/sections/Crowdfunding";
 import PastEventLink from "@/components/sections/PastEventLink";
+import PrivacyPolicy from "@/components/sections/PrivacyPolicy";
+import RelatedLinks from "@/components/sections/RelatedLinks";
 import Sponsors from "@/components/sections/Sponsors";
-import Contact from "@/components/sections/Contact";
-
 
 export default function Home() {
   return (
@@ -24,6 +23,7 @@ export default function Home() {
       <PastEventLink />
       <Sponsors />
       <Contact />
+      <PrivacyPolicy />
 
       <footer className="w-full py-8 text-center text-sm text-slate-400 bg-white">
         <p>© 2026 本当のルーキー祭り 運営</p>

--- a/2026spring/frontend/src/components/Schedule.tsx
+++ b/2026spring/frontend/src/components/Schedule.tsx
@@ -101,6 +101,9 @@ export default function Schedule() {
               </p>
               <p className="text-sm text-slate-600 leading-relaxed">
                 二次創作参加作品が対象となる特別なステージです。
+                <span className="text-red-500 font-bold">
+                  投稿締切：5/31(日) AM4:00
+                </span>
               </p>
             </div>
           </div>

--- a/2026spring/frontend/src/components/Schedule.tsx
+++ b/2026spring/frontend/src/components/Schedule.tsx
@@ -21,13 +21,13 @@ export default function Schedule() {
     },
     {
       title: "決勝(Best)",
-      date: "2026年5月24日(日) 〜",
+      date: "2026年5月25日(日) 〜",
       description: "各Selectionの上位作品による最終決戦！",
       color: "step-accent", // cherry
     },
     {
       title: "結果発表",
-      date: "2026年5月30日(土) 予定",
+      date: "2026年6月11日(土) 予定",
       description: "本サイトおよび公式Xにて最終結果を発表します。",
       color: "step-secondary", // skyblue
     },
@@ -97,7 +97,7 @@ export default function Schedule() {
                 exステージ
               </h5>
               <p className="text-xs text-slate-400 font-semibold mb-3">
-                2026年5月24日(日) 〜 (決勝と同時開催)
+                2026年6月1日(日) 〜
               </p>
               <p className="text-sm text-slate-600 leading-relaxed">
                 二次創作参加作品が対象となる特別なステージです。

--- a/2026spring/frontend/src/components/sections/Contact.tsx
+++ b/2026spring/frontend/src/components/sections/Contact.tsx
@@ -2,7 +2,7 @@ import { MessageCircle } from "lucide-react";
 
 export default function Contact() {
   return (
-    <section className="w-full py-24 bg-slate-50">
+    <section className="w-full py-12 bg-slate-50">
       <div className="max-w-4xl mx-auto px-6">
         <div className="flex items-center gap-3 mb-8">
           <MessageCircle className="text-cherry w-8 h-8" />

--- a/2026spring/frontend/src/components/sections/Crowdfunding.tsx
+++ b/2026spring/frontend/src/components/sections/Crowdfunding.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 
 export default function Crowdfunding() {
   return (
-    <section className="w-full py-24 bg-slate-50">
+    <section className="w-full py-12 bg-slate-50">
       <div className="max-w-4xl mx-auto px-6">
         <div className="flex items-center gap-3 mb-8">
           <HeartHandshake className="text-slate-500 w-8 h-8" />
@@ -28,8 +28,7 @@ export default function Crowdfunding() {
             rel="noopener noreferrer"
             className="text-sm font-medium text-mint hover:underline"
           >
-            ボカロが街を熱くした日を、永遠に―
-            本当の投稿祭セレクションCD制作PJー
+            ボカロが街を熱くした日を、永遠に― 本当の投稿祭セレクションCD制作PJー
           </a>
 
           <div className="mt-6 flex justify-center">

--- a/2026spring/frontend/src/components/sections/PastEventLink.tsx
+++ b/2026spring/frontend/src/components/sections/PastEventLink.tsx
@@ -21,7 +21,7 @@ export default function PastEventLink() {
   ];
 
   return (
-    <section className="w-full py-24 bg-slate-50">
+    <section className="w-full py-12 bg-slate-50">
       <div className="max-w-4xl mx-auto px-6">
         {/* タイトル */}
         <div className="flex items-center gap-3 mb-8">
@@ -53,23 +53,20 @@ export default function PastEventLink() {
 
                 {/* ホバー演出 */}
                 <div className="absolute inset-0 flex items-center justify-center">
-
-                {/* 背景 */}
+                  {/* 背景 */}
                   <div className="absolute inset-0 bg-black/40 transition-all duration-300 group-hover:bg-black/60" />
 
-                {/* テキストまとめて中央固定 */}
+                  {/* テキストまとめて中央固定 */}
                   <div className="relative flex flex-col items-center justify-center text-center">
+                    {/* タイトル */}
+                    <span className="text-white text-lg md:text-xl font-bold transition-all duration-300 group-hover:opacity-0 group-hover:-translate-y-2">
+                      {event.title}
+                    </span>
 
-                {/* タイトル */}
-                  <span className="text-white text-lg md:text-xl font-bold transition-all duration-300 group-hover:opacity-0 group-hover:-translate-y-2">
-                    {event.title}
-                  </span>
-
-               {/* 詳細 */}
-                <span className="absolute text-white text-lg md:text-xl font-bold opacity-0 translate-y-2 transition-all duration-300 group-hover:opacity-100 group-hover:translate-y-0">
-                 詳細を見る
-                </span>
-
+                    {/* 詳細 */}
+                    <span className="absolute text-white text-lg md:text-xl font-bold opacity-0 translate-y-2 transition-all duration-300 group-hover:opacity-100 group-hover:translate-y-0">
+                      詳細を見る
+                    </span>
                   </div>
                 </div>
               </div>

--- a/2026spring/frontend/src/components/sections/PrivacyPolicy.tsx
+++ b/2026spring/frontend/src/components/sections/PrivacyPolicy.tsx
@@ -3,7 +3,25 @@ export default function PrivacyPolicy() {
     <div className="max-w-4xl mx-auto px-6">
       <p className="w-full py-6 text-slate-400 text-center text-sm bg-white">
         当サイトでは、Googleによるアクセス解析ツール「Googleアナリティクス」を使用しています。このGoogleアナリティクスはデータの収集のためにCookieを使用しています。このデータは匿名で収集されており、個人を特定するものではありません。
-        この機能はCookieを無効にすることで収集を拒否することが出来ますので、お使いのブラウザの設定をご確認ください。この規約に関しての詳細はGoogleアナリティクスサービス利用規約のページやGoogleポリシーと規約ページをご覧ください。
+        この機能はCookieを無効にすることで収集を拒否することが出来ますので、お使いのブラウザの設定をご確認ください。この規約に関しての詳細は
+        <a
+          href="https://marketingplatform.google.com/about/analytics/terms/jp/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-mint hover:underline"
+        >
+          Googleアナリティクスサービス利用規約
+        </a>
+        のページや
+        <a
+          href="https://policies.google.com/technologies/ads?hl=ja"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-mint hover:underline"
+        >
+          Googleポリシーと規約
+        </a>
+        ページをご覧ください。
       </p>
     </div>
   );

--- a/2026spring/frontend/src/components/sections/PrivacyPolicy.tsx
+++ b/2026spring/frontend/src/components/sections/PrivacyPolicy.tsx
@@ -1,10 +1,7 @@
 export default function PrivacyPolicy() {
   return (
-    <div className="w-full min-h-[70vh] flex flex-col items-center justify-center p-6 text-center animate-in fade-in duration-500">
-      <h1 className="text-3xl md:text-4xl font-extrabold text-slate-800 mb-4 tracking-tight">
-        プライバシーポリシー
-      </h1>
-      <p className="text-slate-500 font-medium leading-relaxed">
+    <div className="max-w-4xl mx-auto px-6">
+      <p className="w-full py-6 text-slate-400 text-center text-sm bg-white">
         当サイトでは、Googleによるアクセス解析ツール「Googleアナリティクス」を使用しています。このGoogleアナリティクスはデータの収集のためにCookieを使用しています。このデータは匿名で収集されており、個人を特定するものではありません。
         この機能はCookieを無効にすることで収集を拒否することが出来ますので、お使いのブラウザの設定をご確認ください。この規約に関しての詳細はGoogleアナリティクスサービス利用規約のページやGoogleポリシーと規約ページをご覧ください。
       </p>

--- a/2026spring/frontend/src/components/sections/RelatedLinks.tsx
+++ b/2026spring/frontend/src/components/sections/RelatedLinks.tsx
@@ -63,7 +63,7 @@ export default function RelatedLinks() {
   ];
 
   return (
-    <section id="links" className="w-full py-24 bg-slate-50">
+    <section id="links" className="w-full py-12 bg-slate-50">
       <div className="max-w-4xl mx-auto px-6">
         <div className="flex items-center gap-3 mb-8">
           <LinkIcon className="text-mint w-8 h-8" />
@@ -90,9 +90,7 @@ export default function RelatedLinks() {
                   {link.title}
                 </div>
 
-                <div className="text-xs text-slate-500">
-                  {link.desc}
-                </div>
+                <div className="text-xs text-slate-500">{link.desc}</div>
               </a>
             ))}
           </div>
@@ -114,9 +112,7 @@ export default function RelatedLinks() {
                   {link.title}
                 </div>
 
-                <div className="text-xs text-slate-500">
-                  {link.desc}
-                </div>
+                <div className="text-xs text-slate-500">{link.desc}</div>
               </a>
             ))}
           </div>

--- a/2026spring/frontend/src/components/sections/Sponsors.tsx
+++ b/2026spring/frontend/src/components/sections/Sponsors.tsx
@@ -2,7 +2,7 @@ import { HeartHandshake } from "lucide-react";
 
 export default function Sponsors() {
   return (
-    <section className="w-full py-24 bg-slate-50">
+    <section className="w-full py-12 bg-slate-50">
       <div className="max-w-4xl mx-auto px-6">
         <div className="flex items-center gap-3 mb-8">
           <HeartHandshake className="text-slate-500 w-8 h-8" />
@@ -13,9 +13,7 @@ export default function Sponsors() {
         </div>
 
         <div className="p-8 bg-gradient-to-br from-white to-slate-100 rounded-3xl shadow-sm border border-slate-200 mb-6">
-          <h4 className="text-xl font-bold text-slate-800 mb-2">
-            ヴォエ
-          </h4>
+          <h4 className="text-xl font-bold text-slate-800 mb-2">ヴォエ</h4>
 
           <p className="text-slate-600 text-sm mb-6">
             この投稿祭は「ヴォエ」が後援しています。
@@ -32,9 +30,7 @@ export default function Sponsors() {
         </div>
 
         <div className="p-8 bg-gradient-to-br from-white to-slate-100 rounded-3xl shadow-sm border border-slate-200 mb-6">
-          <h4 className="text-xl font-bold text-slate-800 mb-2">
-            NFRSラジオ
-          </h4>
+          <h4 className="text-xl font-bold text-slate-800 mb-2">NFRSラジオ</h4>
 
           <p className="text-slate-600 text-sm mb-6">
             この投稿祭は「NFRSラジオ」が後援しています。

--- a/2026spring/frontend/src/components/sections/privacy_policy.tsx
+++ b/2026spring/frontend/src/components/sections/privacy_policy.tsx
@@ -1,0 +1,13 @@
+export default function PrivacyPolicy() {
+  return (
+    <div className="w-full min-h-[70vh] flex flex-col items-center justify-center p-6 text-center animate-in fade-in duration-500">
+      <h1 className="text-3xl md:text-4xl font-extrabold text-slate-800 mb-4 tracking-tight">
+        プライバシーポリシー
+      </h1>
+      <p className="text-slate-500 font-medium leading-relaxed">
+        当サイトでは、Googleによるアクセス解析ツール「Googleアナリティクス」を使用しています。このGoogleアナリティクスはデータの収集のためにCookieを使用しています。このデータは匿名で収集されており、個人を特定するものではありません。
+        この機能はCookieを無効にすることで収集を拒否することが出来ますので、お使いのブラウザの設定をご確認ください。この規約に関しての詳細はGoogleアナリティクスサービス利用規約のページやGoogleポリシーと規約ページをご覧ください。
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

スケジュールの更新、Googleアナリティクス使用の旨を追記

## 関連Issue

 - #157 

## 変更内容

- 決勝とexのスケジュール更新
- フッターにプライバシーポリシーを追加
- 関連リンク以下のpy値を変更

## 動作確認

- ローカルで確認