### PR TITLE
exの動画取得を止める

### DIFF
--- a/.github/workflows/2026spring_fetch_videos_ex.yml
+++ b/.github/workflows/2026spring_fetch_videos_ex.yml
@@ -2,13 +2,13 @@ name: 2026spring Fetch Videos ex
 
 on:
   workflow_dispatch:  # 手動実行
-  schedule:
+  #schedule:
     #- cron: '0 * * * *'  # 毎時実行
     #- cron: '0 */3 * * *' # 3時間おき実行
     #- cron: '0 */6 * * *' # 6時間おき実行
     #- cron: '0 15 * * *' # 毎日実行（日本時間0時）
-    - cron: '0 21 * * *' # 毎日実行（日本時間6時）
-    - cron: '0 0 * * *' # 毎日実行（日本時間9時）
+    #- cron: '0 21 * * *' # 毎日実行（日本時間6時）
+    #- cron: '0 0 * * *' # 毎日実行（日本時間9時）
 
 jobs:
   run-script:


### PR DESCRIPTION
## 概要
exステージの動画はもう追加されないので、動画取得を止める

## 関連Issue
- Closes #177 

## 変更内容

## 動作確認

## 影響範囲

## 補足